### PR TITLE
#7: Move embedder model name to config

### DIFF
--- a/core/ingestion/embedder.py
+++ b/core/ingestion/embedder.py
@@ -34,15 +34,15 @@ class FakeEmbedder:
 class SentenceTransformerEmbedder:
     """Real embedder using sentence-transformers. Use in integration tests and production."""
 
-    MODEL = "all-MiniLM-L6-v2"
+    DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
-    def __init__(self) -> None:
+    def __init__(self, model: str = DEFAULT_MODEL) -> None:
         logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
         logging.getLogger("sentence_transformers").setLevel(logging.ERROR)
 
         from sentence_transformers import SentenceTransformer
 
-        self._model = SentenceTransformer(self.MODEL)
+        self._model = SentenceTransformer(model)
 
     def embed(self, chunks: list[str]) -> NDArray[np.float32]:
         if not chunks:


### PR DESCRIPTION
Accepts `model` as a constructor arg on `SentenceTransformerEmbedder`, defaulting to `all-MiniLM-L6-v2`. No behaviour change — just removes the hardcoded class constant.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)