### PR TITLE
#42: Apply expressive design system to practice UI

### DIFF
--- a/api/templates/feedback.html
+++ b/api/templates/feedback.html
@@ -1,27 +1,28 @@
 <div id="question-area">
-  <p><strong>Score: {{ result.score }} / 10</strong></p>
+  <p class="score">Score: {{ result.score }} / 10</p>
 
   {% if result.strengths %}
-  <p><strong>Strengths</strong></p>
+  <p class="section-heading">Strengths</p>
   <ul>
     {% for item in result.strengths %}<li>{{ item }}</li>{% endfor %}
   </ul>
   {% endif %}
 
   {% if result.gaps %}
-  <p><strong>Gaps</strong></p>
+  <p class="section-heading">Gaps</p>
   <ul>
     {% for item in result.gaps %}<li>{{ item }}</li>{% endfor %}
   </ul>
   {% endif %}
 
   {% if result.suggested_addition %}
-  <p><strong>Suggested addition:</strong> {{ result.suggested_addition }}</p>
+  <p class="suggested-addition">{{ result.suggested_addition }}</p>
   {% endif %}
 
-  <p><strong>Follow-up:</strong> {{ result.follow_up_question }}</p>
+  <p class="follow-up">{{ result.follow_up_question }}</p>
 
   <button
+    class="next"
     hx-get="/ui/{{ context_name }}/question?query={{ result.follow_up_question | urlencode }}"
     hx-target="#question-area"
     hx-swap="outerHTML"

--- a/api/templates/practice.html
+++ b/api/templates/practice.html
@@ -4,7 +4,130 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ context_name }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
     <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js"></script>
+    <style>
+      :root {
+        --primary: #db2777;
+        --secondary: #2563eb;
+        --surface: #ffffff;
+        --text: #111827;
+        --muted: #6b7280;
+      }
+
+      body {
+        font-family: "IBM Plex Mono", monospace;
+        color: var(--text);
+        background: var(--surface);
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 32px 16px;
+      }
+
+      h1 {
+        font-size: 32px;
+        font-weight: 700;
+        color: var(--primary);
+        margin-bottom: 24px;
+      }
+
+      #question-area {
+        border: 2px solid var(--secondary);
+        border-radius: 6px;
+        padding: 24px;
+      }
+
+      #question-area.htmx-request {
+        color: var(--muted);
+      }
+
+      p {
+        font-size: 18px;
+        line-height: 1.6;
+        margin: 0 0 16px;
+      }
+
+      textarea {
+        width: 100%;
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 16px;
+        border: 2px solid var(--secondary);
+        border-radius: 4px;
+        padding: 12px;
+        box-sizing: border-box;
+        resize: vertical;
+        outline: none;
+      }
+
+      textarea:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 20%, transparent);
+      }
+
+      button {
+        font-family: "IBM Plex Mono", monospace;
+        font-size: 14px;
+        font-weight: 700;
+        border: none;
+        border-radius: 4px;
+        padding: 10px 20px;
+        cursor: pointer;
+      }
+
+      button.submit {
+        background: var(--primary);
+        color: #ffffff;
+        margin-top: 12px;
+      }
+
+      button.submit:hover {
+        background: #be185d;
+      }
+
+      button.next {
+        background: var(--secondary);
+        color: #ffffff;
+        margin-top: 16px;
+      }
+
+      button.next:hover {
+        background: #1d4ed8;
+      }
+
+      .score {
+        font-size: 24px;
+        font-weight: 700;
+        color: var(--primary);
+        margin-bottom: 16px;
+      }
+
+      .section-heading {
+        font-size: 16px;
+        font-weight: 700;
+        color: var(--secondary);
+        margin: 16px 0 8px;
+      }
+
+      ul {
+        margin: 0 0 8px;
+        padding-left: 20px;
+      }
+
+      li {
+        font-size: 16px;
+        margin-bottom: 8px;
+      }
+
+      .suggested-addition {
+        color: var(--muted);
+        font-style: italic;
+      }
+
+      .follow-up {
+        color: var(--primary);
+        font-weight: 600;
+      }
+    </style>
   </head>
   <body>
     <h1>{{ context_name }}</h1>

--- a/api/templates/question.html
+++ b/api/templates/question.html
@@ -9,6 +9,6 @@
     <input type="hidden" name="query" value="{{ query }}" />
     <textarea name="answer" rows="5" placeholder="Your answer..."></textarea>
     <br />
-    <button type="submit">Submit</button>
+    <button type="submit" class="submit">Submit</button>
   </form>
 </div>


### PR DESCRIPTION
## Summary

- IBM Plex Mono font loaded via Google Fonts CDN
- CSS custom properties (pink/blue/surface/text/muted) defined in `practice.html` and inherited by fragments
- `#question-area` styled as a blue-bordered card; Submit button pink, Next button blue
- Feedback fragment uses semantic classes for score, section headings, suggested addition, and follow-up

## Test plan

- [ ] Load `/ui/<context>/practice` — font and card border visible
- [ ] Submit an answer — feedback renders with pink score, blue section headings, italic suggested addition
- [ ] Click "Next question" — question fragment reloads cleanly inside the same card

🤖 Generated with [Claude Code](https://claude.com/claude-code)