### PR TITLE
Fix CI running twice on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

- The bare `push` trigger was firing CI on every PR branch push, in addition to the `pull_request` trigger — resulting in duplicate runs.
- Scoped `push` to `main` only so CI runs once per PR push (via `pull_request`) and once post-merge (via `push: branches: main`).

## Test plan

- [ ] Push a commit to a PR branch and confirm only one CI run is triggered
- [ ] Merge to main and confirm CI runs once

🤖 Generated with [Claude Code](https://claude.com/claude-code)