### PR TITLE
Cache SessionStore instances on app.state

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,6 +34,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise ValueError("GEMINI_API_KEY is not set")
     app.state.anthropic = AsyncAnthropic()
     app.state.gemini = genai.Client()
+    app.state.session_stores = {}  # dict[str, SessionStore], keyed by context name
     yield
 
 
@@ -41,9 +42,17 @@ app = FastAPI(lifespan=lifespan)
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
 
+def _get_session_store(
+    cache: dict[str, SessionStore], store_dir: Path, context: str
+) -> SessionStore:
+    if context not in cache:
+        cache[context] = SessionStore(store_dir, context)
+    return cache[context]
+
+
 @app.get("/ui/{context_name}", response_class=HTMLResponse)
 async def get_ui(request: Request, context_name: str, query: str) -> HTMLResponse:
-    session_store = SessionStore(app.state.store_dir, context_name)
+    session_store = _get_session_store(app.state.session_stores, app.state.store_dir, context_name)
     session_id = session_store.start_session()
     return templates.TemplateResponse(
         request,
@@ -97,7 +106,7 @@ async def post_evaluate_fragment(
         question=question, answer=answer, chunks=chunks, profile=profile
     )
     result = await evaluate_answer(prompt, app.state.anthropic)
-    session_store = SessionStore(app.state.store_dir, context_name)
+    session_store = _get_session_store(app.state.session_stores, app.state.store_dir, context_name)
     attempt_id = session_store.record(session_id, question, answer, result.score)
     return templates.TemplateResponse(
         request,
@@ -137,7 +146,7 @@ async def post_annotate(
 ) -> HTMLResponse:
     if sentiment not in ("up", "down"):
         raise HTTPException(status_code=422, detail="sentiment must be 'up' or 'down'")
-    session_store = SessionStore(app.state.store_dir, context_name)
+    session_store = _get_session_store(app.state.session_stores, app.state.store_dir, context_name)
     session_store.record_annotation(attempt_id, "question", sentiment, comment or None)
     return templates.TemplateResponse(
         request,

--- a/tests/test_api_ui.py
+++ b/tests/test_api_ui.py
@@ -1,11 +1,13 @@
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from api.main import app
+from api.main import _get_session_store, app
 from core.models import EvaluationResult, Question
+from core.session.store import SessionStore
 
 
 @pytest.fixture()
@@ -195,3 +197,31 @@ def test_post_evaluate_fragment_returns_404_for_unknown_context(
 
     assert response.status_code == 404
     assert "unknown" in response.json()["detail"]
+
+
+def test_get_session_store_creates_instance_on_first_call(tmp_path: Path) -> None:
+    cache: dict[str, SessionStore] = {}
+
+    store = _get_session_store(cache, tmp_path, "python")
+
+    assert isinstance(store, SessionStore)
+    assert "python" in cache
+
+
+def test_get_session_store_returns_same_instance_on_second_call(tmp_path: Path) -> None:
+    cache: dict[str, SessionStore] = {}
+
+    first = _get_session_store(cache, tmp_path, "python")
+    second = _get_session_store(cache, tmp_path, "python")
+
+    assert first is second
+
+
+def test_get_session_store_creates_separate_instances_per_context(tmp_path: Path) -> None:
+    cache: dict[str, SessionStore] = {}
+
+    python_store = _get_session_store(cache, tmp_path, "python")
+    sql_store = _get_session_store(cache, tmp_path, "sql")
+
+    assert python_store is not sql_store
+    assert len(cache) == 2


### PR DESCRIPTION
## Summary

- Initialises `app.state.session_stores = {}` in `lifespan`
- Replaces per-request `SessionStore(...)` instantiation with an inline cache lookup in `get_ui`, `post_evaluate_fragment`, and `post_annotate`
- Consistent with how `Retriever` is already handled

Closes #68

## Test plan

- [ ] All existing tests pass (`uv run pytest`)
- [ ] Manual: two requests for the same context should hit `CREATE TABLE IF NOT EXISTS` only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)