### PR TITLE
Suppress HF_TOKEN and position_ids warnings from embedder (#15 #16)

### DIFF
--- a/core/ingestion/embedder.py
+++ b/core/ingestion/embedder.py
@@ -37,8 +37,10 @@ class SentenceTransformerEmbedder:
     DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
     def __init__(self, model: str = DEFAULT_MODEL) -> None:
-        logging.getLogger("huggingface_hub").setLevel(logging.ERROR)
-        logging.getLogger("sentence_transformers").setLevel(logging.ERROR)
+        import transformers
+
+        logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
+        transformers.utils.logging.set_verbosity_error()  # type: ignore[no-untyped-call]
 
         from sentence_transformers import SentenceTransformer
 


### PR DESCRIPTION
## Summary

Fixes both noisy warnings that appeared on every embedder load:

- **#15** `Warning: You are sending unauthenticated requests to the HF Hub...` — was targeting the `huggingface_hub` parent logger; actual source is `huggingface_hub.utils._http`
- **#16** `BertModel LOAD REPORT / embeddings.position_ids UNEXPECTED` — suppressed via `transformers.utils.logging.set_verbosity_error()` which is the correct API for the transformers logging wrapper

Both fixed in `SentenceTransformerEmbedder.__init__`.

## Test plan

- [ ] Run `uv run python -c "from core.ingestion.embedder import SentenceTransformerEmbedder; SentenceTransformerEmbedder()"` — neither warning should appear
- [ ] All 103 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)