### PR TITLE
Tighten evaluation prompt to avoid penalising presentation

### DIFF
--- a/core/evaluation/prompt.py
+++ b/core/evaluation/prompt.py
@@ -28,6 +28,9 @@ Experience level: {profile.experience_level}
 
 <instructions>
 Evaluate the answer honestly. Do not be encouraging or inflate the score.
-Identify what the learner got right, what they missed, and what they could add.
+Identify what the learner got right and what factual points they missed or got wrong.
+Only flag something as a gap if it affects the correctness or meaningful completeness of the answer.
+Do not penalise for not citing sources, not quoting the material, or not explaining
+their reasoning — only the substance matters.
 Suggest a follow-up question that probes a gap in their understanding.
 </instructions>"""


### PR DESCRIPTION
## Summary

- Only flag gaps that affect factual correctness or meaningful completeness
- Do not penalise for not citing sources, quoting the material, or explaining reasoning

## Motivation

Evaluation feedback was flagging presentational issues (missing citations, not explaining reasoning) as gaps even when the core answer was correct. This surfaced as noise in the feedback that frustrated learners.

## Test plan

- [ ] Run a practice session and verify evaluation gaps only reference factual issues
- [ ] Existing prompt tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)