### PR TITLE
feat: add tool init command to ingest a source directory

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,7 @@ from core.evaluation.evaluate import evaluate_answer
 from core.evaluation.prompt import build_evaluation_prompt
 from core.ingestion.embedder import SentenceTransformerEmbedder
 from core.ingestion.ingest import ingest
+from core.ingestion.sources import walk_source_dir
 from core.ingestion.store import ChunkStore
 from core.models import UserProfile
 from core.question.generate import generate_question
@@ -17,6 +18,26 @@ from core.session.store import SessionStore
 from core.settings import STORE_DIR as DEFAULT_STORE
 
 app = typer.Typer()
+
+
+@app.command()
+def init(
+    source: Path = typer.Option(..., help="Directory of source documents"),
+    context: str = typer.Option(..., help="Context name"),
+    store_dir: Path = typer.Option(DEFAULT_STORE, help="Path to the chunk store"),
+) -> None:
+    """Ingest all documents in a source directory into a context."""
+    if not source.exists() or not source.is_dir():
+        typer.echo(f"Error: source directory not found: {source}", err=True)
+        raise typer.Exit(code=1)
+    paths = [p for p in walk_source_dir(source) if p.name != "GOAL.md"]
+    if not paths:
+        typer.echo(f"Error: no supported files found in {source}", err=True)
+        raise typer.Exit(code=1)
+    store = ChunkStore(store_dir)
+    embedder = SentenceTransformerEmbedder()
+    ingest(context=context, paths=paths, embedder=embedder, store=store)
+    typer.echo(f"Ingested {len(paths)} file(s) into context '{context}'")
 
 
 @app.command()

--- a/core/ingestion/ingest.py
+++ b/core/ingestion/ingest.py
@@ -1,8 +1,17 @@
 from pathlib import Path
 
+import pypdf
+
 from core.ingestion.chunker import chunk_document
 from core.ingestion.embedder import Embedder
 from core.ingestion.store import ChunkStore
+
+
+def _read_file(path: Path) -> str:
+    if path.suffix == ".pdf":
+        reader = pypdf.PdfReader(path)
+        return "\n\n".join(page.extract_text() or "" for page in reader.pages)
+    return path.read_text()
 
 
 def ingest(context: str, paths: list[Path], embedder: Embedder, store: ChunkStore) -> None:
@@ -12,7 +21,7 @@ def ingest(context: str, paths: list[Path], embedder: Embedder, store: ChunkStor
     for path in paths:
         if not path.exists():
             raise FileNotFoundError(f"Source file not found: {path}")
-        all_chunks.extend(chunk_document(path.read_text()))
+        all_chunks.extend(chunk_document(_read_file(path)))
 
     embeddings = embedder.embed(all_chunks)
     store.save(context, all_chunks, embeddings)

--- a/core/ingestion/sources.py
+++ b/core/ingestion/sources.py
@@ -2,6 +2,15 @@ from pathlib import Path
 
 import yaml
 
+_SUPPORTED_EXTENSIONS = {".md", ".txt", ".pdf"}
+
+
+def walk_source_dir(source_dir: Path) -> list[Path]:
+    """Return all supported document files in source_dir, recursively."""
+    return sorted(
+        p for p in source_dir.rglob("*") if p.is_file() and p.suffix in _SUPPORTED_EXTENSIONS
+    )
+
 
 def load_sources(sources_file: Path) -> list[Path]:
     """Load and validate local file paths from a sources.yaml config."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "numpy>=2.4.3",
     "python-multipart>=0.0.22",
+    "pypdf>=5.0.0",
     "pyyaml>=6.0.3",
     "sentence-transformers>=5.3.0",
     "typer>=0.12.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,100 @@
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from cli.main import app
+from core.ingestion.embedder import FakeEmbedder
+from core.ingestion.store import ChunkStore
 
 runner = CliRunner()
+
+
+def test_init_ingests_supported_files(tmp_path: Path) -> None:
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "a.md").write_text("First paragraph.\n\nSecond paragraph.")
+    (source / "b.txt").write_text("Another paragraph.")
+    (source / "GOAL.md").write_text("This is the goal.")
+    store_dir = tmp_path / "store"
+
+    with patch("cli.main.SentenceTransformerEmbedder", return_value=FakeEmbedder(dim=8)):
+        result = runner.invoke(
+            app,
+            ["init", "--source", str(source), "--context", "test", "--store-dir", str(store_dir)],
+        )
+
+    assert result.exit_code == 0
+    assert "2" in result.output  # GOAL.md excluded by init → 2 files (a.md, b.txt)
+    store = ChunkStore(store_dir)
+    chunks, embeddings = store.load("test")
+    assert len(chunks) > 0
+    assert embeddings.shape[0] == len(chunks)
+
+
+def test_init_excludes_goal_md(tmp_path: Path) -> None:
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "GOAL.md").write_text("goal description")
+    store_dir = tmp_path / "store"
+
+    # Only GOAL.md present — should fail as no supported files remain
+    result = runner.invoke(
+        app,
+        ["init", "--source", str(source), "--context", "test", "--store-dir", str(store_dir)],
+    )
+    assert result.exit_code == 1
+
+
+def test_init_fails_for_missing_source_dir(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--source",
+            str(tmp_path / "nonexistent"),
+            "--context",
+            "test",
+            "--store-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+
+
+def test_init_fails_when_no_supported_files(tmp_path: Path) -> None:
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "notes.py").write_text("not supported")
+
+    result = runner.invoke(
+        app,
+        ["init", "--source", str(source), "--context", "test", "--store-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("context", ["my-context"])
+def test_init_wipes_and_rebuilds(tmp_path: Path, context: str) -> None:
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "doc.md").write_text("Only paragraph.")
+    store_dir = tmp_path / "store"
+
+    with patch("cli.main.SentenceTransformerEmbedder", return_value=FakeEmbedder(dim=8)):
+        runner.invoke(
+            app,
+            ["init", "--source", str(source), "--context", context, "--store-dir", str(store_dir)],
+        )
+        runner.invoke(
+            app,
+            ["init", "--source", str(source), "--context", context, "--store-dir", str(store_dir)],
+        )
+
+    store = ChunkStore(store_dir)
+    chunks, _ = store.load(context)
+    assert len(chunks) == 1  # not doubled
 
 
 def test_question_prompt_fails_fast_for_unknown_context(tmp_path: Path) -> None:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -2,7 +2,42 @@ from pathlib import Path
 
 import pytest
 
-from core.ingestion.sources import load_sources
+from core.ingestion.sources import load_sources, walk_source_dir
+
+
+def test_walk_source_dir_finds_supported_types(tmp_path: Path) -> None:
+    (tmp_path / "doc.md").write_text("markdown")
+    (tmp_path / "notes.txt").write_text("text")
+    (tmp_path / "report.pdf").write_bytes(b"%PDF-1.4")
+    (tmp_path / "script.py").write_text("python")
+
+    paths = walk_source_dir(tmp_path)
+    names = {p.name for p in paths}
+    assert names == {"doc.md", "notes.txt", "report.pdf"}
+
+
+def test_walk_source_dir_includes_goal_md(tmp_path: Path) -> None:
+    # walk_source_dir is domain-agnostic; GOAL.md exclusion is the caller's responsibility
+    (tmp_path / "GOAL.md").write_text("goal")
+    (tmp_path / "doc.md").write_text("content")
+
+    paths = walk_source_dir(tmp_path)
+    names = {p.name for p in paths}
+    assert "GOAL.md" in names
+    assert "doc.md" in names
+
+
+def test_walk_source_dir_recurses_subdirectories(tmp_path: Path) -> None:
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "nested.md").write_text("nested")
+
+    paths = walk_source_dir(tmp_path)
+    assert any(p.name == "nested.md" for p in paths)
+
+
+def test_walk_source_dir_empty_directory(tmp_path: Path) -> None:
+    assert walk_source_dir(tmp_path) == []
 
 
 def test_load_local_files(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -591,6 +591,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "jinja2" },
     { name = "numpy" },
+    { name = "pypdf" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sentence-transformers" },
@@ -616,6 +617,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.68.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "numpy", specifier = ">=2.4.3" },
+    { name = "pypdf", specifier = ">=5.0.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "sentence-transformers", specifier = ">=5.3.0" },
@@ -1158,6 +1160,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/fb/dc2e8cb006e80b0020ed20d8649106fe4274e82d8e756ad3e24ade19c0df/pypdf-6.9.1.tar.gz", hash = "sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d", size = 5311551, upload-time = "2026-03-17T10:46:07.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/f4/75543fa802b86e72f87e9395440fe1a89a6d149887e3e55745715c3352ac/pypdf-6.9.1-py3-none-any.whl", hash = "sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f", size = 333661, upload-time = "2026-03-17T10:46:06.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `tool init --source <dir> --context <name>` to replace manual file-by-file ingestion
- `walk_source_dir()` discovers `.md`, `.txt`, `.pdf` files recursively, excluding `GOAL.md`
- PDF text extraction via `pypdf`; wipe-on-reinit is implicit (store overwrites on save)

## Test plan

- [ ] `uv run pytest tests/test_sources.py tests/test_cli.py tests/test_ingest.py` — all pass
- [ ] Manual: `uv run learn init --source <real-dir> --context <name>` with mixed file types
- [ ] Verify `uv run learn question <name> "<topic>"` works after init

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)