### PR TITLE
feat: warn and exit when context already exists on tool init

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -28,17 +28,14 @@ def init(
     store_dir: Path = typer.Option(DEFAULT_STORE, help="Path to the chunk store"),
 ) -> None:
     """Ingest all documents in a source directory into a context."""
-    try:
-        existing = ContextStore(store_dir).load_context(context)
+    if not source.exists() or not source.is_dir():
+        typer.echo(f"Error: source directory not found: {source}", err=True)
+        raise typer.Exit(code=1)
+    existing = ContextStore(store_dir).load_context(context)
+    if existing:
         typer.echo(f"Context '{context}' already exists. Focus areas:")
         for area in existing.focus_areas:
             typer.echo(f"  - {area}")
-        typer.echo("Run with --force to reingest and overwrite.")
-        raise typer.Exit(code=1)
-    except FileNotFoundError:
-        pass
-    if not source.exists() or not source.is_dir():
-        typer.echo(f"Error: source directory not found: {source}", err=True)
         raise typer.Exit(code=1)
     paths = [p for p in walk_source_dir(source) if p.name != "GOAL.md"]
     if not paths:

--- a/core/ingestion/store.py
+++ b/core/ingestion/store.py
@@ -21,10 +21,10 @@ class ContextStore:
             yaml.dump(metadata.model_dump(), default_flow_style=False)
         )
 
-    def load_context(self, context: str) -> ContextMetadata:
+    def load_context(self, context: str) -> ContextMetadata | None:
         ctx_file = self.base_dir / context / "context.yaml"
         if not ctx_file.exists():
-            raise FileNotFoundError(f"No context found for '{context}'")
+            return None
         data = yaml.safe_load(ctx_file.read_text())
         return ContextMetadata(**data)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,6 @@ def test_init_warns_and_exits_when_context_exists(tmp_path: Path) -> None:
     assert "my-context" in result.output
     assert "LLM evaluation" in result.output
     assert "Python async" in result.output
-    assert "--force" in result.output
 
 
 def test_init_ingests_supported_files(tmp_path: Path) -> None:
@@ -99,6 +98,7 @@ def test_init_extracts_and_saves_context_yaml(source_dir: Path, tmp_path: Path) 
 
     assert result.exit_code == 0
     loaded = ContextStore(store_dir).load_context("test")
+    assert loaded is not None
     assert loaded.goal == _FAKE_METADATA.goal
     assert loaded.focus_areas == _FAKE_METADATA.focus_areas
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -17,6 +17,7 @@ def test_context_store_round_trip(tmp_path: Path) -> None:
     store.save_context("my-context", metadata)
     loaded = store.load_context("my-context")
 
+    assert loaded is not None
     assert loaded.goal == metadata.goal
     assert loaded.focus_areas == metadata.focus_areas
 
@@ -30,13 +31,13 @@ def test_context_store_overwrites_existing(tmp_path: Path) -> None:
     store.save_context("ctx", new)
     loaded = store.load_context("ctx")
 
+    assert loaded is not None
     assert loaded.goal == "new goal"
 
 
-def test_context_store_missing_raises(tmp_path: Path) -> None:
+def test_context_store_returns_none_when_missing(tmp_path: Path) -> None:
     store = ContextStore(tmp_path)
-    with pytest.raises(FileNotFoundError):
-        store.load_context("does-not-exist")
+    assert store.load_context("does-not-exist") is None
 
 
 def test_store_and_load_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds `ContextMetadata` dataclass and `ContextStore` (save/load `context.yaml`) to `core/ingestion/store.py`
- Guards `tool init`: if `context.yaml` already exists, prints existing focus areas and exits 1 without touching the vector store
- Unit tests for `ContextStore` round-trip and the CLI guard

## Test plan
- [ ] `uv run pytest tests/test_store.py tests/test_cli.py`
- [ ] Run `tool init` on an existing context — should warn and exit without changes
- [ ] Run `tool init` on a new context — should succeed as before

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)