### PR TITLE
feat: surface bank questions in practice UI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -366,12 +366,16 @@ async def post_flag_annotation(
 
 
 @app.get("/contexts/{context_name}/questions")
-async def get_bank_question(context_name: str, pick: str | None = None) -> dict[str, object]:
+async def get_bank_question(
+    context_name: str,
+    pick: str | None = None,
+    focus_area: str | None = None,
+) -> dict[str, object]:
     if pick != "random":
         logger.warning("422 invalid pick param: %r", pick)
         raise HTTPException(status_code=422, detail="pick must be 'random'")
     bank_store = _get_bank_store(app.state.bank_stores, app.state.store_dir, context_name)
-    question = await asyncio.to_thread(bank_store.get_random)
+    question = await asyncio.to_thread(bank_store.get_random, focus_area)
     if question is None:
         return {"question": None}
     return {
@@ -381,6 +385,34 @@ async def get_bank_question(context_name: str, pick: str | None = None) -> dict[
             "question": question.question,
         }
     }
+
+
+@app.get("/ui/{context_name}/question/bank", response_class=HTMLResponse)
+async def get_bank_question_fragment(
+    request: Request,
+    context_name: str,
+    focus_area: str,
+    session_id: str,
+) -> HTMLResponse:
+    bank_store = _get_bank_store(app.state.bank_stores, app.state.store_dir, context_name)
+    question = await asyncio.to_thread(bank_store.get_random, focus_area)
+    if question is None:
+        return templates.TemplateResponse(
+            request,
+            "bank_empty.html",
+            {"context_name": context_name, "focus_area": focus_area, "session_id": session_id},
+        )
+    return templates.TemplateResponse(
+        request,
+        "question.html",
+        {
+            "context_name": context_name,
+            "question": question.question,
+            "question_id": question.id,
+            "query": focus_area,
+            "session_id": session_id,
+        },
+    )
 
 
 @app.get("/health")

--- a/api/templates/bank_empty.html
+++ b/api/templates/bank_empty.html
@@ -1,0 +1,9 @@
+<div id="question-area">
+  <p class="muted">No questions in the bank for this area yet.</p>
+  <button
+    class="skip"
+    hx-get="/ui/{{ context_name }}/question?query={{ focus_area | urlencode }}&session_id={{ session_id }}"
+    hx-target="#question-area"
+    hx-swap="outerHTML"
+  >Generate a question</button>
+</div>

--- a/api/templates/practice.html
+++ b/api/templates/practice.html
@@ -13,7 +13,7 @@
     <h1>{{ context_name }}</h1>
     <div
       id="question-area"
-      hx-get="/ui/{{ context_name }}/question?query={{ query | urlencode }}&session_id={{ session_id }}"
+      hx-get="/ui/{{ context_name }}/question/bank?focus_area={{ query | urlencode }}&session_id={{ session_id }}"
       hx-trigger="load"
       hx-swap="outerHTML"
     >

--- a/core/question/store.py
+++ b/core/question/store.py
@@ -42,12 +42,18 @@ class QuestionBankStore:
             ).fetchall()
             return [BankQuestion(id=row[0], focus_area=row[1], question=row[2]) for row in rows]
 
-    def get_random(self) -> BankQuestion | None:
-        """Return a random question from the bank, or None if the bank is empty."""
+    def get_random(self, focus_area: str | None = None) -> BankQuestion | None:
+        """Return a random question from the bank, or None if the bank is empty.
+
+        If focus_area is provided, restrict to questions with that focus area.
+        """
+        sql = "SELECT id, focus_area, question FROM bank_questions"
+        params: tuple[str, ...] = ()
+        if focus_area is not None:
+            sql += " WHERE focus_area = ?"
+            params = (focus_area,)
         with sqlite3.connect(self._db_path) as conn:
-            row = conn.execute(
-                "SELECT id, focus_area, question FROM bank_questions ORDER BY RANDOM() LIMIT 1"
-            ).fetchone()
+            row = conn.execute(sql + " ORDER BY RANDOM() LIMIT 1", params).fetchone()
         if row is None:
             return None
         return BankQuestion(id=row[0], focus_area=row[1], question=row[2])

--- a/tests/test_api_bank.py
+++ b/tests/test_api_bank.py
@@ -8,7 +8,7 @@ from api.main import app
 from core.models import BankQuestion
 
 
-def _make_client(mock_bank_store: MagicMock) -> Generator[TestClient]:
+def _make_client(mock_bank_store: MagicMock) -> Generator[tuple[TestClient, MagicMock]]:
     with (
         patch("api.main.SentenceTransformerEmbedder"),
         patch("api.main.AsyncAnthropic"),
@@ -18,7 +18,7 @@ def _make_client(mock_bank_store: MagicMock) -> Generator[TestClient]:
         patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
         TestClient(app) as c,
     ):
-        yield c
+        yield c, mock_bank_store
 
 
 @pytest.fixture()
@@ -27,13 +27,24 @@ def client_with_question() -> Generator[TestClient]:
     mock_store.get_random.return_value = BankQuestion.from_parts(
         "Agent Development", "What is an agent loop?"
     )
-    yield from _make_client(mock_store)
+    for client, _ in _make_client(mock_store):
+        yield client
 
 
 @pytest.fixture()
 def client_empty_bank() -> Generator[TestClient]:
     mock_store = MagicMock()
     mock_store.get_random.return_value = None
+    for client, _ in _make_client(mock_store):
+        yield client
+
+
+@pytest.fixture()
+def client_with_question_and_mock() -> Generator[tuple[TestClient, MagicMock]]:
+    mock_store = MagicMock()
+    mock_store.get_random.return_value = BankQuestion.from_parts(
+        "Agent Development", "What is an agent loop?"
+    )
     yield from _make_client(mock_store)
 
 
@@ -45,6 +56,15 @@ def test_get_bank_question_returns_question(client_with_question: TestClient) ->
     assert body["question"]["focus_area"] == "Agent Development"
     assert body["question"]["question"] == "What is an agent loop?"
     assert "id" in body["question"]
+
+
+def test_get_bank_question_passes_focus_area_to_store(
+    client_with_question_and_mock: tuple[TestClient, MagicMock],
+) -> None:
+    client, mock_store = client_with_question_and_mock
+    client.get("/contexts/myctx/questions?pick=random&focus_area=Agent+Development")
+
+    mock_store.get_random.assert_called_with("Agent Development")
 
 
 def test_get_bank_question_returns_null_when_empty(client_empty_bank: TestClient) -> None:
@@ -64,3 +84,34 @@ def test_get_bank_question_returns_422_for_invalid_pick(client_empty_bank: TestC
     response = client_empty_bank.get("/contexts/myctx/questions?pick=list")
 
     assert response.status_code == 422
+
+
+def test_get_bank_question_fragment_returns_question_html(client_with_question: TestClient) -> None:
+    response = client_with_question.get(
+        "/ui/myctx/question/bank?focus_area=Agent+Development&session_id=sess-1"
+    )
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "What is an agent loop?" in response.text
+
+
+def test_get_bank_question_fragment_returns_generate_prompt_when_empty(
+    client_empty_bank: TestClient,
+) -> None:
+    response = client_empty_bank.get(
+        "/ui/myctx/question/bank?focus_area=Agent+Development&session_id=sess-1"
+    )
+
+    assert response.status_code == 200
+    assert "Generate a question" in response.text
+
+
+def test_get_bank_question_fragment_generate_button_links_to_generation_endpoint(
+    client_empty_bank: TestClient,
+) -> None:
+    response = client_empty_bank.get(
+        "/ui/myctx/question/bank?focus_area=Agent+Development&session_id=sess-1"
+    )
+
+    assert "/ui/myctx/question" in response.text

--- a/tests/test_api_ui.py
+++ b/tests/test_api_ui.py
@@ -72,6 +72,12 @@ def test_get_ui_triggers_question_load_on_page_load(client: TestClient) -> None:
     assert "hx-trigger" in response.text
 
 
+def test_get_ui_loads_from_bank_endpoint(client: TestClient) -> None:
+    response = client.get("/ui/my-context?query=topic")
+
+    assert "/ui/my-context/question/bank" in response.text
+
+
 def test_get_ui_without_query_shows_focus_area_picker(client: TestClient) -> None:
     app.state.context_store = MagicMock()
     app.state.context_store.load_context.return_value = METADATA

--- a/tests/test_load_questions.py
+++ b/tests/test_load_questions.py
@@ -127,6 +127,20 @@ def test_store_get_random_returns_none_when_empty(tmp_path: Path) -> None:
     assert store.get_random() is None
 
 
+def test_store_get_random_filters_by_focus_area(tmp_path: Path) -> None:
+    store = QuestionBankStore(tmp_path, "ctx")
+    store.add([BankQuestion.from_parts("A", "Q1"), BankQuestion.from_parts("B", "Q2")])
+    result = store.get_random(focus_area="A")
+    assert result is not None
+    assert result.focus_area == "A"
+
+
+def test_store_get_random_returns_none_for_unmatched_focus_area(tmp_path: Path) -> None:
+    store = QuestionBankStore(tmp_path, "ctx")
+    store.add([BankQuestion.from_parts("A", "Q1")])
+    assert store.get_random(focus_area="B") is None
+
+
 def test_store_uses_separate_db_per_context(tmp_path: Path) -> None:
     s1 = QuestionBankStore(tmp_path, "ctx1")
     s2 = QuestionBankStore(tmp_path, "ctx2")


### PR DESCRIPTION
Closes #138

## Summary
- `get_random(focus_area)` filters by focus area when provided
- `GET /contexts/{context}/questions?pick=random&focus_area=...` passes focus area through to the store
- New `GET /ui/{context}/question/bank` HTML endpoint: returns a question fragment from the bank, or a "Generate a question" prompt when the bank is empty for that area
- `practice.html` now loads from the bank endpoint on page load instead of the generation flow

## Test plan
- [ ] Click a focus area on the start page — question from bank appears
- [ ] Click a focus area when bank is empty — "Generate a question" button appears; clicking it triggers RAG generation
- [ ] `GET /contexts/{ctx}/questions?pick=random&focus_area=X` returns only questions matching that area
- [ ] All 188 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)