### PR TITLE
chore(db): housekeeping — index, N+1 fix, question_id in API

### DIFF
--- a/alembic/versions/002_idx_attempts_question_id.py
+++ b/alembic/versions/002_idx_attempts_question_id.py
@@ -1,0 +1,25 @@
+"""add index on attempts.question_id
+
+Revision ID: b4e7f91c2a83
+Revises: c3f8a2d1e094
+Create Date: 2026-03-25
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e7f91c2a83"
+down_revision: str | None = "c3f8a2d1e094"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE INDEX IF NOT EXISTS idx_attempts_question_id ON attempts(question_id)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_attempts_question_id")

--- a/api/main.py
+++ b/api/main.py
@@ -17,12 +17,12 @@ from google import genai
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, Response
 
-from api.models import EvaluateRequest, EvaluationResponse
+from api.models import EvaluateRequest, EvaluationResponse, QuestionResponse
 from core.evaluation.evaluate import evaluate_answer
 from core.evaluation.prompt import build_evaluation_prompt
 from core.ingestion.embedder import SentenceTransformerEmbedder
 from core.ingestion.store import ChunkStore, ContextStore
-from core.models import Question, UserProfile
+from core.models import UserProfile
 from core.question.generate_gemini import generate_question_gemini
 from core.question.prompt import build_question_prompt
 from core.question.store import QuestionBankStore
@@ -423,7 +423,7 @@ async def health() -> dict[str, str]:
 
 
 @app.get("/contexts/{context_name}/question")
-async def get_question(context_name: str, query: str) -> Question:
+async def get_question(context_name: str, query: str) -> QuestionResponse:
     try:
         results = await asyncio.to_thread(app.state.retriever.retrieve, context_name, query, k=5)
         chunks = [chunk for chunk, _ in results]
@@ -434,7 +434,8 @@ async def get_question(context_name: str, query: str) -> Question:
     metadata = app.state.context_store.load_context(context_name)
     profile = UserProfile(experience_level="beginner")
     prompt = build_question_prompt(chunks, profile, metadata)
-    return await generate_question_gemini(prompt, app.state.gemini)
+    question = await generate_question_gemini(prompt, app.state.gemini)
+    return QuestionResponse(text=question.text, question_id=str(uuid.uuid4()))
 
 
 @app.post("/contexts/{context_name}/evaluate")

--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,11 @@
 from pydantic import BaseModel, Field
 
 
+class QuestionResponse(BaseModel):
+    text: str
+    question_id: str
+
+
 class EvaluateRequest(BaseModel):
     query: str = Field(description="RAG retrieval query — used to find relevant context chunks")
     question: str

--- a/core/session/store.py
+++ b/core/session/store.py
@@ -147,25 +147,29 @@ class SessionStore:
                 att.score,
                 att.result_json
             FROM annotations a
-            LEFT JOIN attempts att ON (
-                (a.question_id IS NOT NULL AND att.question_id = a.question_id)
-                OR (a.question_id IS NULL AND a.attempt_id IS NOT NULL AND att.id = a.attempt_id)
-            )
+            LEFT JOIN attempts att ON att.question_id = a.question_id
             {where}
             ORDER BY a.id DESC
         """
         with sqlite3.connect(self._db_path) as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(query, params).fetchall()
+
+            attempt_ids = [row["attempt_id"] for row in rows if row["attempt_id"] is not None]
+            chunks_by_attempt: dict[int, list[tuple[str, float | None]]] = {}
+            if attempt_ids:
+                placeholders = ",".join("?" * len(attempt_ids))
+                chunk_rows = conn.execute(
+                    f"SELECT attempt_id, chunk_text, score FROM chunks"
+                    f" WHERE attempt_id IN ({placeholders}) ORDER BY id",
+                    attempt_ids,
+                ).fetchall()
+                for c in chunk_rows:
+                    chunks_by_attempt.setdefault(c[0], []).append((c[1], c[2]))
+
             result = []
             for row in rows:
-                chunks: list[tuple[str, float | None]] = []
-                if row["attempt_id"] is not None:
-                    chunk_rows = conn.execute(
-                        "SELECT chunk_text, score FROM chunks WHERE attempt_id = ? ORDER BY id",
-                        (row["attempt_id"],),
-                    ).fetchall()
-                    chunks = [(c[0], c[1]) for c in chunk_rows]
+                aid = row["attempt_id"]
                 result.append(
                     {
                         "id": row["id"],
@@ -179,7 +183,7 @@ class SessionStore:
                         "answer_text": row["answer_text"],
                         "score": row["score"],
                         "result_json": row["result_json"],
-                        "chunks": chunks,
+                        "chunks": chunks_by_attempt.get(aid, []) if aid is not None else [],
                     }
                 )
             return result

--- a/tests/test_api_question.py
+++ b/tests/test_api_question.py
@@ -33,7 +33,9 @@ def test_get_question_returns_200(client: TestClient, mock_retriever: MagicMock)
         response = client.get("/contexts/geography/question?query=capitals")
 
     assert response.status_code == 200
-    assert response.json() == {"text": "What is the capital of France?"}
+    body = response.json()
+    assert body["text"] == "What is the capital of France?"
+    assert isinstance(body["question_id"], str) and len(body["question_id"]) == 36  # UUID
 
 
 def test_get_question_returns_404_for_unknown_context(


### PR DESCRIPTION
## Summary

- **#93** — Alembic migration 002: index on `attempts(question_id)`, used by the annotation join
- **#97** — Simplify `load_annotations` LEFT JOIN to `att.question_id = a.question_id` (drops dead `attempt_id` fallback — `record_annotation` has always been `question_id`-keyed)
- **#98** — Replace per-row chunk SELECT in `load_annotations` with a single `IN (...)` query batched over all annotation attempt IDs
- **#92** — Add `QuestionResponse(text, question_id)` to `api/models`; `GET /contexts/{ctx}/question` now returns a server-generated UUID alongside the question text

## Test plan

- [x] `uv run pytest` — all 189 tests pass
- [ ] `GET /contexts/<ctx>/question?query=<q>` returns `{"text": "...", "question_id": "<uuid>"}`
- [x] After first request to a context, verify migration ran: `sqlite3 contexts/store/<ctx>/sessions.db "SELECT name FROM sqlite_master WHERE type='index';"` — should include `idx_attempts_question_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)