### PR TITLE
feat: add question_id to Question model

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import time
-import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -128,14 +127,13 @@ async def get_question_fragment(
     profile = UserProfile(experience_level="beginner")
     prompt = build_question_prompt(chunks, profile, metadata)
     question = await generate_question_gemini(prompt, app.state.gemini)
-    question_id = str(uuid.uuid4())
     return templates.TemplateResponse(
         request,
         "question.html",
         {
             "context_name": context_name,
             "question": question.text,
-            "question_id": question_id,
+            "question_id": question.question_id,
             "query": query,
             "session_id": session_id,
         },
@@ -466,7 +464,7 @@ async def get_question(context_name: str, query: str) -> QuestionResponse:
     profile = UserProfile(experience_level="beginner")
     prompt = build_question_prompt(chunks, profile, metadata)
     question = await generate_question_gemini(prompt, app.state.gemini)
-    return QuestionResponse(text=question.text, question_id=str(uuid.uuid4()))
+    return QuestionResponse(text=question.text, question_id=question.question_id)
 
 
 @app.post("/contexts/{context_name}/evaluate", tags=["evaluation"])

--- a/core/models.py
+++ b/core/models.py
@@ -1,4 +1,5 @@
 import hashlib
+import uuid
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -17,6 +18,7 @@ class ContextMetadata(BaseModel):
 
 class Question(BaseModel):
     text: str
+    question_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
 
 
 class EvaluationResult(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,14 @@
+import uuid
+
+from core.models import Question
+
+
+def test_question_auto_generates_valid_uuid() -> None:
+    q = Question(text="x")
+    uuid.UUID(q.question_id)  # raises ValueError if not a valid UUID
+
+
+def test_question_ids_are_unique() -> None:
+    q1 = Question(text="x")
+    q2 = Question(text="x")
+    assert q1.question_id != q2.question_id


### PR DESCRIPTION
Closes #92

## Summary
- `Question` model now auto-generates a `question_id` UUID at parse time, so a stable identifier travels with the question regardless of caller
- Both `get_question_fragment` (UI) and `get_question` (JSON API) now read `question.question_id` instead of generating their own UUIDs
- `uuid` import removed from `api/main.py` (no longer needed)
- API response shape is unchanged

## Test plan
- [ ] All 205 existing tests pass
- [ ] `Question(text="x").question_id` is a valid UUID
- [ ] JSON API `/contexts/{context_name}/question` response includes `question_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)