### PR TITLE
docs(learnings): add str.format_map single-pass behaviour note

### DIFF
--- a/docs/learnings/python.md
+++ b/docs/learnings/python.md
@@ -95,3 +95,30 @@ and evaluates in one step, avoiding the double call:
 The assignment `s := chunk.strip()` evaluates to the stripped string. An empty string
 is falsy, so whitespace-only items are filtered out, and `s` in the output expression
 reuses the already-computed value.
+
+---
+
+## str.format_map() is single-pass — substituted values are never re-evaluated
+
+`str.format_map(values)` scans the template once, replaces each `{placeholder}` with
+the corresponding value from the dict, and returns the result. It never looks at the
+substituted values again.
+
+```python
+template = "Hello {name}, your input was: {material}"
+material = "Call func with {key: value}"  # contains braces
+
+result = template.format_map({"name": "Alice", "material": material})
+# → "Hello Alice, your input was: Call func with {key: value}"
+# The {key: value} in `material` is NOT interpreted as a placeholder.
+```
+
+This means passing user-controlled content (e.g. RAG chunks, user goals) as values is
+safe — Python never does a second pass over what was substituted.
+
+The only real failure mode is a `{placeholder}` in the **template itself** that isn't
+in the dict — a developer error (typo or missing key), caught immediately at test time.
+
+Contrast with recursive template engines (e.g. PHP double-evaluation) where the output
+of one substitution becomes input to another pass. Python's `str.format_map` is not
+that — it's closer to a named find-and-replace over a fixed set of slots.


### PR DESCRIPTION
## Summary

- Adds a note to `docs/learnings/python.md` explaining that `str.format_map()` does a single-pass substitution and never re-evaluates substituted values
- Includes a concrete example showing user-controlled content with braces is safe to pass as values
- Notes the only real failure mode (unrecognised placeholder in the template itself)
- Contrasts with recursive template engines to clarify the mental model

Came up during review of PR #156 (prompt template extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)