### PR TITLE
docs: review ADR 013 and 014 against chat integration design

### DIFF
--- a/docs/decisions/013-rag-scope-structured-context-in-prompt.md
+++ b/docs/decisions/013-rag-scope-structured-context-in-prompt.md
@@ -1,0 +1,99 @@
+# ADR 013 — Scope RAG to large external docs; inject structured context directly
+
+## Status
+Proposed — lower urgency given chat integration direction (see note below)
+
+## Context
+
+The current ingestion pipeline chunks and embeds everything — background docs, role description, GOAL.md, and
+any other files in the source directory. At question generation time, the top-k chunks
+are retrieved and injected into the prompt.
+
+This works for large, unstructured corpora where you don't know which bits are relevant
+at query time. But it is the wrong tool for structured, bounded documents like a
+background summary or role description, where:
+
+- The full document fits comfortably in a prompt
+- Chunking loses structure and introduces retrieval noise
+- Retrieval may return irrelevant chunks when a simpler direct injection would be exact
+
+The annotation debug session (#115) surfaced a concrete example: a question about
+Python's "We are all responsible users" philosophy was generated because the retriever
+pulled chunks from a general Python style guide. The learner's goal (FDE interview
+prep) and focus areas were not in the prompt at all — only the retrieved chunks were.
+The root cause was that structured context (goal, focus areas, learner background) was not being used
+to steer generation.
+
+## Decision
+
+Split the knowledge base into two tiers:
+
+**Tier 1 — Structured context (injected directly into the system prompt)**
+- Learner background (e.g. experience summary)
+- Target role or goal description
+- Goal statement and focus areas (from `context.yaml`)
+- Coverage gaps (from `context.yaml`)
+- Session history and weak areas
+
+These are small, structured, and always fully relevant. Inject them whole.
+
+**Tier 2 — Reference corpus (chunked, embedded, retrieved via RAG)**
+- External docs fetched from URLs (Anthropic docs, Python references, MCP spec, etc.)
+- Large supplementary reading material
+
+These are large and unstructured. RAG is the right tool — retrieve top-k chunks
+relevant to the current focus area at question generation time.
+
+## What changes
+
+- `init` distinguishes between local structured files and URL-sourced material
+- Local structured files (background, role description) are stored as full text, not chunked
+- URL-sourced material is chunked and embedded as before
+- Question generation prompt includes full structured context in the system prompt,
+  plus RAG-retrieved chunks from the reference corpus
+- `context.yaml` records which files are structured context vs reference material
+
+## Why this is better
+
+- No retrieval noise from chunking structured docs — the model sees the whole thing
+- Focus areas and goal directly steer question generation, not just hint at it
+- RAG is used where it adds value (large external docs), not where it doesn't
+- Coverage reporting (which focus areas have reference material) becomes meaningful
+- Simpler mental model: structured things go in the prompt, large things go in RAG
+
+## Trade-offs
+
+- Local files must be classified as structured context or reference material during
+  `init`. The LLM can infer this (short structured docs → direct; long docs → reference), or
+  the user can signal it in `GOAL.md` under a `# Sources` section.
+- If a structured file is very large (e.g. a 50-page report), direct injection may
+  hit context limits. In that case it should be treated as reference material instead.
+  The LLM can make this call during init based on token count.
+- The vector store becomes reference-corpus-only. Existing contexts with structured docs
+  chunked into the store will need to be reinitialised.
+
+## Relationship to other decisions
+
+- Supersedes the implicit assumption in #101–#105 that all local files are chunked
+- Complements ADR 012 (prompt traceability) — the system prompt structure is now
+  more significant and worth tracking
+- Enables the coverage report (focus area → reference chunks) to be meaningful
+
+## Revisit if
+
+The structured context (background docs + session history) grows large enough to approach
+context window limits. At that point, selective injection or summarisation of
+structured context would be worth considering.
+
+## Note — chat integration design (2026-03-27)
+
+The chat integration direction (see `docs/design/chat-integration-mcp.md`) shifts
+question generation and evaluation to the user's LLM chat (Claude Projects). The
+user's CV, background docs, and goal are already in Claude's context — the tool
+doesn't need to inject Tier 1 structured context for generation if generation happens
+in chat.
+
+This ADR remains valid for the **server-side generation fallback** (web practice
+loop without MCP), but its urgency is reduced. Tier 2 RAG (external reference docs)
+is still relevant for that path. Implement when server-side generation quality becomes
+a priority again.

--- a/docs/decisions/014-question-bank-over-generation.md
+++ b/docs/decisions/014-question-bank-over-generation.md
@@ -1,0 +1,85 @@
+# ADR 014 — Prioritise question bank over on-demand generation
+
+## Status
+Accepted — implemented (#132, #50, #131 closed)
+
+## Context
+
+The current practice loop generates a question on demand: RAG retrieves chunks from
+the knowledge base, the model produces a question, the learner answers, and the
+evaluation runs. This works when the learner has no prior question set and needs the
+tool to surface what to practise.
+
+But the primary value of the tool is the practice loop itself — answer, evaluate,
+feedback — not question generation. When the learner already has a well-calibrated
+set of questions (curated manually, exported from prior sessions, or sourced
+externally), on-demand generation adds latency and non-determinism without adding
+value. The tool should not force the learner through generation when better material
+already exists.
+
+There is also a structural issue: the current page loads directly into question
+generation with no way to direct focus. The learner cannot express which topic area
+they want to practise before a question appears.
+
+## Decision
+
+The practice page (`/ui/{context}`) is restructured around a question bank as the
+primary source:
+
+1. **Page load shows a focus area selector**, drawn from `context.yaml`. The learner
+   picks an area (or "any") before a question is shown.
+
+2. **Selecting a focus area serves a question from the bank** for that area. No
+   generation, no RAG retrieval — a direct read from the question bank.
+
+3. **A "Generate" button remains available** as an explicit action. It triggers the
+   existing generation flow with the selected focus area injected into the prompt.
+   The current behaviour is fully preserved; it just becomes opt-in rather than
+   the default.
+
+The question bank is populated from a structured file (e.g. `questions.yaml` in the
+context directory) via a CLI command. The file is parsed directly into question
+records — no chunking, no embedding. This is a distinct path from the RAG ingestion
+pipeline and does not interact with the vector store.
+
+## What this deprioritises
+
+- Ingestion pipeline improvements (URL sources, chunking refinements, coverage
+  reporting) — still valuable, lower urgency when a bank already exists
+- Question generation improvements — still the fallback and explicitly available,
+  but no longer the critical path
+
+## Consequences
+
+- The practice loop works end-to-end without any RAG or generation if the bank is
+  populated — simpler, faster, more predictable
+- Focus area selection becomes the natural entry point for a session, which feeds
+  naturally into weak area surfacing and spaced repetition later
+- The generate path is preserved and still used when the bank has no question for
+  the selected area, or when the learner explicitly wants a generated question
+
+## Implementation order
+
+1. `#132` — Load question bank from file (no chunking) ✓
+2. `#50` — Serve questions from bank given a focus area ✓
+3. `#131` — Focus area selector on the practice page ✓
+
+## Note — chat integration design (2026-03-27)
+
+The question bank population path has expanded beyond the original CLI command.
+Questions can now be imported from an AI chat response via the setup page (#142/#143)
+— the user pastes a structured response from Claude and the tool parses it into
+`questions.yaml`. This is now the primary population path.
+
+The MCP tool `create_context()` (#169) will further streamline this — Claude calls
+the tool directly without a copy-paste step.
+
+The "Generate" button as explicit fallback remains unchanged and aligns with the
+chat integration design, where on-demand generation is de-prioritised in favour of
+the question bank.
+
+## Revisit if
+
+The question bank proves too rigid — e.g. the learner exhausts the bank and needs
+generated questions to fill gaps. At that point, blending bank and generated
+questions (weighted by coverage) would be the natural next step.


### PR DESCRIPTION
## Summary

- **ADR 013**: Still proposed and unimplemented. Adds a note that urgency is reduced — the Tier 1 structured context problem is now handled naturally by Claude Projects in the chat integration path. Remains valid for the server-side generation fallback.
- **ADR 014**: Marks as implemented (#132, #50, #131 all closed). Notes the expanded question bank population path via chat import flow (#142/#143) and the upcoming MCP `create_context()` tool (#169).

## Test plan

- [ ] Both ADRs read correctly and reflect the current design