### PR TITLE
perf(ci): cache mypy and uv deps to cut CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/cache@v4
+        with:
+          path: .mypy_cache
+          key: mypy-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: mypy-${{ runner.os }}-
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary

- Add `actions/cache@v4` for `.mypy_cache` keyed on `uv.lock` — mypy was taking ~54s cold; warm cache should drop to ~5–10s
- Add `cache-dependency-glob: "uv.lock"` to `setup-uv` to ensure uv's cache key tracks the lockfile

## Test plan

- [ ] Check first run completes (cache miss, mypy ~54s as before)
- [ ] Check second run hits the mypy cache and mypy step drops significantly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)