### PR TITLE
revert(ci): remove mypy and venv caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,6 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
-
-      - uses: actions/cache@v4
-        with:
-          path: .mypy_cache
-          key: mypy-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: mypy-${{ runner.os }}-
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
Reverts #175. Common practice (uv download cache only) is sufficient for now — will revisit if CI time becomes a real issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)