### PR TITLE
chore: move project skills into .claude/commands/

### DIFF
--- a/.claude/commands/debug-annotation.md
+++ b/.claude/commands/debug-annotation.md
@@ -1,0 +1,141 @@
+# Debug Annotation Skill
+
+Given a flagged annotation ID, load everything the system knew at the time and analyse why the question may have been unhelpful.
+
+## Usage
+
+`/debug-annotation [annotation_id]`
+
+If no annotation ID is given, defaults to the **latest flagged annotation** (highest `flagged_at` timestamp across all context DBs).
+
+Output is split into two clearly labelled sections: **What the system had** (concrete, from DB and files) and **Analysis** (LLM-generated reasoning).
+
+## Steps
+
+### Step 1: Locate the DB and context
+
+Use the session store SQLite DB. Find it via `STORE_DIR` from `core/settings.py`, or ask the user if unclear. The DB is at `$STORE_DIR/<context>/sessions.db`.
+
+If no annotation ID is given, scan all context DBs to find the annotation with the latest `flagged_at` timestamp.
+
+### Step 2: Load concrete data from the DB
+
+Run the following queries against the SQLite DB using the Bash tool:
+
+```sql
+-- If no annotation_id given, find latest flagged first:
+SELECT a.id, '<context>' as context
+FROM annotations a
+WHERE a.flagged_at IS NOT NULL
+ORDER BY a.flagged_at DESC
+LIMIT 1;
+
+-- Annotation + attempt
+SELECT
+  a.id as annotation_id,
+  a.sentiment,
+  a.comment,
+  a.flagged_at,
+  a.target_type,
+  att.question_text,
+  att.answer_text,
+  att.score,
+  att.prompt_text,
+  att.timestamp
+FROM annotations a
+JOIN attempts att ON att.id = a.attempt_id
+WHERE a.id = <annotation_id>;
+
+-- RAG chunks for this attempt
+SELECT chunk_text, score
+FROM chunks
+WHERE attempt_id = (
+  SELECT attempt_id FROM annotations WHERE id = <annotation_id>
+)
+ORDER BY score DESC;
+```
+
+Also load `context.yaml` from `$STORE_DIR/<context>/context.yaml`.
+
+### Step 3: Output — "What the system had"
+
+Print this section with a clear header. Include all concrete data, formatted for readability:
+
+```
+## What the system had
+
+### Context
+Goal: ...
+Focus areas:
+  - ...
+
+### Annotation
+ID: ...
+Sentiment: up/down
+Comment: "..."
+Flagged at: ...
+Target: question/evaluation
+
+### Attempt
+Question: ...
+Answer: ...
+Score: .../10
+Timestamp: ...
+
+### RAG chunks retrieved (ordered by similarity score)
+1. [score: 0.87] "chunk text..."
+2. [score: 0.74] "chunk text..."
+...
+
+### Prompt sent to LLM
+<full prompt text>
+```
+
+### Step 4: Output — "Analysis"
+
+Print this section with a clear header. Work through each area explicitly, showing reasoning:
+
+```
+## Analysis
+```
+
+**Retrieval assessment**
+- Are the chunks relevant to the question asked?
+- Do the similarity scores suggest confident or borderline retrieval?
+- Is there a mismatch between the chunks and the stated focus areas?
+- Verdict: retrieval looks good / retrieval is suspect / retrieval is the likely problem
+
+**Prompt assessment**
+- Are the focus areas from `context.yaml` present in the prompt?
+- Is the learner's goal clearly framed?
+- Any structural issues with how the prompt is constructed?
+- Verdict: prompt looks good / prompt has issues / prompt is the likely problem
+
+**Goal alignment**
+- Does the question address a stated focus area?
+- Is the question pitched at an appropriate level given the source material?
+- Would this question actually help the learner prepare for their goal?
+- Verdict: aligned / misaligned / unclear
+
+**Root cause**
+Categorise as one of:
+- **Retrieval problem** — wrong or irrelevant chunks fetched
+- **Prompt problem** — focus areas not used, bad framing
+- **Data problem** — source material doesn't cover this topic well enough
+- **Goal mismatch** — question is technically valid but not useful for this learner's goal
+- **Unknown** — not enough signal to determine
+
+**Proposed fix**
+One concrete suggestion. Examples:
+- Tweak the question generation prompt to better use focus areas
+- Update `GOAL.md` to be more specific and reingest
+- Add more source material on this topic
+- Adjust RAG retrieval k or similarity threshold
+- No fix needed — one-off bad question, not systematic
+
+## Notes
+
+- Keep the two sections strictly separate. Never mix DB facts with LLM reasoning.
+- If data is missing (e.g. `prompt_text` is null because #118 isn't landed), note it explicitly rather than skipping the section.
+- If RAG chunks are missing (e.g. #116 isn't landed), note it and do best-effort analysis on what is available.
+- Flag if the annotation looks like a one-off vs a systemic pattern.

--- a/.claude/commands/refine-issue.md
+++ b/.claude/commands/refine-issue.md
@@ -1,0 +1,103 @@
+# Refine Issue Skill
+
+Given a GitHub issue number (or the current issue being discussed), run a structured refinement conversation before any implementation begins.
+
+## Usage
+
+`/refine-issue <issue-number>`
+
+If no issue number is given, use the issue currently being discussed in the conversation.
+
+## Steps
+
+Work through these phases in order. Do not move to the next phase until the current one is resolved.
+
+### Phase 1: Fetch and read the issue
+
+Use `gh issue view <number>` to get the full issue text. Read it carefully.
+
+### Phase 2: Split check
+
+Ask: can this issue be broken into two or more independent pieces that could ship separately?
+
+Good signals that it should be split:
+- It contains "and" connecting two distinct behaviours
+- Part A must exist before Part B can be built (dependency order)
+- Part A and Part B could be tested independently
+- One part is pure data/storage and the other is behaviour on top of it
+
+If it should be split: propose the split clearly, identify which part is the prerequisite, and ask the user whether to update the current issue and create a new one, or create two new ones. Do not proceed until this is resolved.
+
+### Phase 3: Testability check
+
+Ask: how would you test this? Can you write a unit or integration test that fails before the work and passes after?
+
+If the answer is unclear or "no", surface that — untestable issues often signal fuzzy scope or missing design decisions. Do not block on this, but flag it.
+
+### Phase 4: Value and alignment check
+
+Ask:
+- What does the learner actually gain from this?
+- Does it align with the core goal (personalised learning that adapts to the learner over time)?
+- Is there a simpler version that delivers most of the value?
+
+Surface any concerns, but defer to the user's judgement.
+
+### Phase 5: Design discussion
+
+Only after phases 2-4 are resolved: discuss the implementation approach. Cover:
+- Data model (if any new data is introduced)
+- Where the logic lives (which module/layer)
+- What changes at the boundary (CLI, API, or both)
+- Any hard-to-reverse decisions that need to be made now vs. later
+
+If any hard-to-reverse decisions are made (data store choice, storage format, module boundaries), propose capturing them as an ADR in `docs/decisions/`. Check the existing ADRs for the next number and format to follow.
+
+Do not suggest editing any files during this phase unless the user explicitly asks.
+
+### Phase 6: Commit breakdown
+
+After the user confirms the design: propose a sequence of atomic, independently-testable commits that together implement the issue. Each commit should:
+- Do one logical thing
+- Leave the codebase in a working state
+- Have a clear test that validates it
+
+Present the breakdown as a numbered list. Ask the user to confirm or adjust before any implementation begins.
+
+### Phase 7: Update the issue
+
+After the user confirms the commit breakdown, append the agreed design and commit breakdown to the GitHub issue body.
+
+1. Get the current body: `gh issue view <number> --json body -q .body`
+2. Append two sections:
+
+```
+## Design
+- Key decisions (data model, module location, notable tradeoffs)
+- Dependencies on other issues (if any)
+
+## Commits
+1. ...
+2. ...
+```
+
+3. Write back with `gh issue edit <number> --body "<updated body>"`
+
+Confirm to the user once done.
+
+### Phase 8: Move to Todo
+
+After updating the issue, move it to "Todo" in the project board:
+
+1. Get the item ID: `gh project item-list 6 --owner lmchoi --format json | python3 -c "import json,sys; items=json.load(sys.stdin)['items']; item=next((i for i in items if i.get('content',{}).get('number')==<number>),None); print(item['id'] if item else 'not found')"`
+2. Set status to Todo: `gh project item-edit --project-id PVT_kwHOAHDUcM4BSQiR --id <item-id> --field-id PVTSSF_lAHOAHDUcM4BSQiRzg_2JWs --single-select-option-id 2488e2e8`
+
+If the issue is not in the project yet, add it first: `gh project item-add 6 --owner lmchoi --url <issue-url>`
+
+Confirm to the user once done.
+
+## Notes
+
+- This is a conversation, not a one-shot analysis. Pause and wait for user input at each phase.
+- Keep proposals concrete — name the files, modules, and data models.
+- Flag scope creep if the design discussion starts pulling in work that belongs in a different issue.

--- a/.claude/commands/serve.md
+++ b/.claude/commands/serve.md
@@ -1,0 +1,35 @@
+# Serve Skill
+
+Kill any existing process on port 8000, start the dev server, and tail logs.
+
+## Usage
+
+`/serve`
+
+## Steps
+
+1. Kill whatever is on port 8000 (if anything):
+
+```bash
+lsof -ti :8000 | xargs kill -9 2>/dev/null; true
+```
+
+2. Start the server in the background using the Makefile target:
+
+```bash
+make serve 2>&1
+```
+
+Run this with `run_in_background=true`. Note the output file path from the result.
+
+3. Wait ~10 seconds for startup (embedder model load takes a few seconds).
+
+4. Tail the output file to show the user the startup logs:
+
+```bash
+cat <output_file>
+```
+
+Print the logs to the user. If startup completed successfully, tell them the server is running at http://localhost:8000 and http://localhost:8000/docs for the API docs.
+
+If startup failed (e.g. address already in use, missing env var), surface the error clearly.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,86 @@
+# Start Issue Skill
+
+Given a refined GitHub issue number, create a worktree, launch a background subagent to implement it, and move the issue to "In Progress" on the project board.
+
+## Usage
+
+`/start-issue <issue-number>`
+
+The issue must already be refined (design and commit breakdown present in the issue body). If it hasn't been refined yet, run `/refine-issue` first.
+
+## Steps
+
+### Step 1: Fetch the issue
+
+Run `gh issue view <number>` to get the full issue text. Read it carefully — you need the commit breakdown and any design notes.
+
+If the issue body has no `## Commits` section, stop and tell the user to run `/refine-issue <number>` first.
+
+### Step 2: Determine the branch name
+
+Use the format `feat/<number>-<short-slug>` where the slug is a 2-4 word kebab-case summary of the issue title.
+
+Examples:
+- #144 "Capture-mode practice page" → `feat/144-capture-mode`
+- #187 "Document database schemas" → `feat/187-schema-docs`
+
+### Step 3: Create the worktree
+
+```bash
+git worktree add .claude/worktrees/<number>-<slug> -b feat/<number>-<slug>
+```
+
+If the branch already exists (worktree was previously created), just confirm it exists and proceed.
+
+### Step 4: Move the issue to In Progress
+
+1. Check if the issue is already in the project:
+```bash
+gh project item-list 6 --owner lmchoi --format json --limit 100 | python3 -c "
+import json,sys
+items=json.load(sys.stdin)['items']
+item=next((i for i in items if i.get('content',{}).get('number')==<number>),None)
+print(item['id'] if item else 'not found')
+"
+```
+
+2. If not found, add it first:
+```bash
+gh project item-add 6 --owner lmchoi --url <issue-url>
+```
+Then re-run the lookup.
+
+3. Set status to In Progress:
+```bash
+gh project item-edit --project-id PVT_kwHOAHDUcM4BSQiR --id <item-id> --field-id PVTSSF_lAHOAHDUcM4BSQiRzg_2JWs --single-select-option-id 194746c4
+```
+
+### Step 5: Launch the background subagent
+
+Launch an Agent with `run_in_background: true`. The agent prompt must include:
+
+- The worktree path: `/Users/mandy/workspace/learning-tool/.claude/worktrees/<number>-<slug>`
+- The branch name
+- The full issue spec (problem, solution, acceptance criteria, commit breakdown)
+- These standing instructions:
+  - Work entirely within the worktree — do not touch the main working directory
+  - Read existing code before writing anything — follow existing patterns exactly (FastAPI routes, HTMX templates, store usage, etc.)
+  - Each commit must be a complete red→green cycle — never commit a failing test
+  - Run checks before each commit:
+    ```
+    cd <worktree-path>
+    uv run ruff check .
+    uv run ruff format --check .
+    uv run mypy .
+    uv run pytest
+    ```
+  - Async throughout — use `asyncio.gather` for independent work, `asyncio.to_thread` for blocking I/O
+  - Do not push, do not create a PR
+  - The codebase is domain-agnostic — do not hardcode domain-specific logic into core
+
+### Step 6: Confirm to the user
+
+Tell the user:
+- The branch name and worktree path
+- That the issue has been moved to In Progress
+- That the agent is running in the background


### PR DESCRIPTION
## Summary

- Moves `refine-issue`, `start-issue`, `serve`, and `debug-annotation` from `~/.claude/skills/` into `.claude/commands/` so they live in the repo alongside `update-notes.md`
- All four skills are project-specific (hardcode this repo's GitHub project, owner, and paths) so they belong here, not in the home directory

Closes #189

## Test plan

- [ ] All checks pass (ruff, mypy, pytest — 275 tests)
- [ ] `/refine-issue`, `/start-issue`, `/serve`, `/debug-annotation` available as slash commands in this project

## After merging

Delete the originals from the local machine:
```bash
rm -rf ~/.claude/skills/refine-issue ~/.claude/skills/start-issue ~/.claude/skills/serve ~/.claude/skills/debug-annotation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)