### PR TITLE
fix: remove background agent launch from start-issue skill

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,3 +1,7 @@
+---
+model: sonnet
+---
+
 # Implement Issue Skill
 
 Implement a refined GitHub issue inside its worktree. Run this after `/start-issue` has set up the worktree and branch.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,3 +1,7 @@
+---
+model: haiku
+---
+
 # Start Issue Skill
 
 Given a refined GitHub issue number, create a worktree and branch, and move the issue to "In Progress" on the project board.


### PR DESCRIPTION
Removes the automatic background agent spawn from `/start-issue`. The skill now only creates the worktree and moves the issue to In Progress. Users can then run `/implement-issue` manually if they want to start implementing.

This prevents unnecessary background agent spawning and excessive token usage.