### PR TITLE
feat: session results page

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -434,6 +434,35 @@ async def post_capture_paste_back(
     return RedirectResponse(url=url, status_code=303)
 
 
+@app.get(
+    "/ui/{context_name}/sessions/{session_id}", response_class=HTMLResponse, include_in_schema=False
+)
+async def get_session_results(request: Request, context_name: str, session_id: str) -> HTMLResponse:
+    session_store = _get_session_store(app.state.session_stores, app.state.store_dir, context_name)
+    session = session_store.load_session(session_id)
+    if session is None:
+        return templates.TemplateResponse(
+            request,
+            "session.html",
+            {"context_name": context_name, "session": None, "attempts": []},
+            status_code=404,
+        )
+    attempts = []
+    for a in session.attempts:
+        result = None
+        if a.result_json:
+            try:
+                result = json.loads(a.result_json)
+            except json.JSONDecodeError:
+                logger.warning("malformed result_json for attempt in session %s", session_id)
+        attempts.append({"attempt": a, "result": result})
+    return templates.TemplateResponse(
+        request,
+        "session.html",
+        {"context_name": context_name, "session": session, "attempts": attempts},
+    )
+
+
 @app.get("/ui/{context_name}/history", response_class=HTMLResponse, include_in_schema=False)
 async def get_history(
     request: Request,

--- a/api/templates/session.html
+++ b/api/templates/session.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ context_name }} — {% if session is none %}session not found{% else %}session results{% endif %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" />
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <h1>{{ context_name }}</h1>
+    <a class="history-link" href="/ui/{{ context_name | urlencode }}/history">← back</a>
+
+    {% if session is none %}
+    <p class="muted">Session not found.</p>
+    {% else %}
+    <div class="session-card">
+      <p class="session-meta">
+        {{ session.started_at[:10] }}
+        &nbsp;·&nbsp;
+        {{ attempts | length }} question{{ 's' if attempts | length != 1 else '' }}
+        {% if attempts %}
+        &nbsp;·&nbsp;
+        avg {{ (attempts | map(attribute='attempt') | map(attribute='score') | sum / attempts | length) | round(1) }}/10
+        {% endif %}
+      </p>
+
+      {% for item in attempts %}
+      <div class="attempt-card">
+        <p class="attempt-question">{{ item.attempt.question_text }}</p>
+        <p class="attempt-answer muted">{{ item.attempt.answer_text }}</p>
+        <p class="score">{{ item.attempt.score }}/10</p>
+
+        {% if item.result %}
+        {% if item.result.strengths %}
+        <p class="section-heading">Strengths</p>
+        <ul>
+          {% for s in item.result.strengths %}<li>{{ s }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if item.result.gaps %}
+        <p class="section-heading">Gaps</p>
+        <ul>
+          {% for g in item.result.gaps %}<li>{{ g }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if item.result.missing_points %}
+        <p class="section-heading">Missing points</p>
+        <ul>
+          {% for m in item.result.missing_points %}<li>{{ m }}</li>{% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if item.result.suggested_addition %}
+        <p class="suggested-addition">{{ item.result.suggested_addition }}</p>
+        {% endif %}
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </body>
+</html>

--- a/tests/test_api_session_results.py
+++ b/tests/test_api_session_results.py
@@ -1,0 +1,125 @@
+import json
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.session.models import QuestionAttempt, SessionRecord
+
+
+@pytest.fixture()
+def client_and_store() -> Generator[tuple[TestClient, MagicMock]]:
+    mock_session_store = MagicMock()
+    app.state.session_stores = {}
+    with (
+        patch("api.main.SentenceTransformerEmbedder"),
+        patch("api.main.AsyncAnthropic"),
+        patch("api.main.genai"),
+        patch("api.main.SessionStore", return_value=mock_session_store),
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        TestClient(app) as c,
+    ):
+        yield c, mock_session_store
+
+
+def _attempt(
+    question: str = "What is X?",
+    answer: str = "It is Y.",
+    score: int = 7,
+    result: dict[str, object] | None = None,
+) -> QuestionAttempt:
+    return QuestionAttempt(
+        session_id="abc123",
+        question_text=question,
+        answer_text=answer,
+        score=score,
+        timestamp="2026-03-25T10:00:00+00:00",
+        result_json=json.dumps(result) if result else None,
+    )
+
+
+def _session(attempts: list[QuestionAttempt]) -> SessionRecord:
+    return SessionRecord(
+        session_id="abc123",
+        context="my-context",
+        started_at="2026-03-25T09:00:00+00:00",
+        attempts=attempts,
+    )
+
+
+def test_get_session_results_returns_200(
+    client_and_store: tuple[TestClient, MagicMock],
+) -> None:
+    client, store = client_and_store
+    store.load_session.return_value = _session([_attempt()])
+
+    response = client.get("/ui/my-context/sessions/abc123")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+
+def test_get_session_results_shows_attempts(
+    client_and_store: tuple[TestClient, MagicMock],
+) -> None:
+    client, store = client_and_store
+    store.load_session.return_value = _session(
+        [_attempt(question="What is async?", answer="Non-blocking.", score=8)]
+    )
+
+    response = client.get("/ui/my-context/sessions/abc123")
+
+    assert "What is async?" in response.text
+    assert "Non-blocking." in response.text
+    assert "8/10" in response.text
+
+
+def test_get_session_results_unknown_session_returns_404(
+    client_and_store: tuple[TestClient, MagicMock],
+) -> None:
+    client, store = client_and_store
+    store.load_session.return_value = None
+
+    response = client.get("/ui/my-context/sessions/unknown-id")
+
+    assert response.status_code == 404
+    assert "text/html" in response.headers["content-type"]
+    assert "not found" in response.text.lower()
+
+
+def test_get_session_results_shows_evaluation_breakdown(
+    client_and_store: tuple[TestClient, MagicMock],
+) -> None:
+    client, store = client_and_store
+    result = {
+        "score": 7,
+        "strengths": ["Good structure."],
+        "gaps": ["Missing context."],
+        "missing_points": ["Edge case"],
+        "suggested_addition": "Consider X.",
+        "follow_up_question": None,
+    }
+    store.load_session.return_value = _session([_attempt(result=result)])
+
+    response = client.get("/ui/my-context/sessions/abc123")
+
+    assert "Good structure." in response.text
+    assert "Missing context." in response.text
+    assert "Edge case" in response.text
+    assert "Consider X." in response.text
+
+
+def test_get_session_results_malformed_result_json_still_renders(
+    client_and_store: tuple[TestClient, MagicMock],
+) -> None:
+    client, store = client_and_store
+    attempt = _attempt(score=6)
+    attempt.result_json = "not valid json {"
+    store.load_session.return_value = _session([attempt])
+
+    response = client.get("/ui/my-context/sessions/abc123")
+
+    assert response.status_code == 200
+    assert "6/10" in response.text


### PR DESCRIPTION
Adds `GET /ui/{context}/sessions/{session_id}` — the destination for the link returned by the `end_session` MCP tool.

## Changes
- New route in `api/main.py` that loads a session and renders all attempts with scores and evaluation breakdowns
- New `api/templates/session.html` template — reuses attempt-card structure from `history.html`
- Returns 404 with a friendly message for unknown session IDs

## Tests
- Happy path: page loads, shows questions/answers/scores/evaluation
- 404 path: unknown session_id returns 404 HTML response with "not found" message

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)