### PR TITLE
feat: create_context MCP tool with draft review flow (#217)

### DIFF
--- a/adapters/mcp/server.py
+++ b/adapters/mcp/server.py
@@ -129,5 +129,46 @@ async def end_session(context: str) -> str:
     return f"{BASE_URL}/ui/{context}/sessions/{session_id}"
 
 
+@mcp.tool()
+async def create_context(name: str, goal: str, focus_areas: list[dict[str, object]]) -> str:
+    """Create a new learning context draft and return a review URL.
+
+    Args:
+        name: Short, slug-friendly name for the context (e.g., 'react-hooks').
+        goal: The high-level learning goal.
+        focus_areas: List of dicts with 'name' (str) and 'questions' (list of str).
+            Example: [{"name": "Hooks", "questions": ["What is a hook?"]}]
+    """
+    url = f"{API_URL}/api/contexts/{name}/draft"
+    payload = {
+        "goal": goal,
+        "focus_areas": focus_areas,
+    }
+
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            # Handle potential double slashes in BASE_URL + review_url
+            base = BASE_URL.rstrip("/")
+            review = data["review_url"].lstrip("/")
+            review_url = f"{base}/{review}"
+            return f"Draft created! Review and confirm here: {review_url}"
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 422:
+                try:
+                    detail = e.response.json().get("detail", str(e))
+                    return f"Validation error: {detail}"
+                except Exception:
+                    return f"Validation error: {e.response.text}"
+            return f"Error creating draft: {e}"
+        except Exception as e:
+            return (
+                f"Error connecting to API at {API_URL}: {e}. "
+                "Make sure the FastAPI server is running."
+            )
+
+
 if __name__ == "__main__":
     mcp.run(transport="stdio")

--- a/api/main.py
+++ b/api/main.py
@@ -17,8 +17,16 @@ from google import genai
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, Response
 
-from api.models import AttemptRequest, EvaluateRequest, EvaluationResponse, QuestionResponse
-from core.context_import.parser import parse_import
+from api.models import (
+    AttemptRequest,
+    DraftRequest,
+    DraftResponse,
+    EvaluateRequest,
+    EvaluationResponse,
+    QuestionResponse,
+)
+from core.context_import.draft_store import DraftStore
+from core.context_import.parser import ImportedContext, parse_import
 from core.context_name import validate_context_name
 from core.evaluation.evaluate import evaluate_answer
 from core.evaluation.export_prompt import build_export_prompt
@@ -65,6 +73,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("retriever ready")
     app.state.store_dir = store_dir
     app.state.context_store = ContextStore(store_dir)
+    app.state.draft_store = DraftStore(store_dir)
     if not os.environ.get("GEMINI_API_KEY"):
         raise ValueError("GEMINI_API_KEY is not set")
     app.state.anthropic = AsyncAnthropic()
@@ -164,6 +173,41 @@ async def post_import(
         context_name,
         len(imported.focus_areas),
     )
+    return templates.TemplateResponse(
+        request,
+        "import_review.html",
+        {
+            "context_name": context_name,
+            "goal": imported.goal,
+            "focus_areas_questions": imported.questions,
+        },
+    )
+
+
+@app.post("/api/contexts/{context_name}/draft", response_model=DraftResponse)
+async def create_draft(request: Request, context_name: str, body: DraftRequest) -> DraftResponse:
+    try:
+        validate_context_name(context_name)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    questions = [(fa.name, fa.questions) for fa in body.focus_areas]
+    imported = ImportedContext(goal=body.goal, questions=questions)
+
+    draft_id = app.state.draft_store.save(context_name, imported)
+    review_url = f"/ui/{context_name}/review/{draft_id}"
+
+    return DraftResponse(draft_id=draft_id, review_url=review_url)
+
+
+@app.get(
+    "/ui/{context_name}/review/{draft_id}", response_class=HTMLResponse, include_in_schema=False
+)
+async def get_review(request: Request, context_name: str, draft_id: str) -> HTMLResponse:
+    imported = app.state.draft_store.load(context_name, draft_id)
+    if not imported:
+        raise HTTPException(status_code=404, detail="Draft not found")
+
     return templates.TemplateResponse(
         request,
         "import_review.html",

--- a/api/models.py
+++ b/api/models.py
@@ -30,3 +30,18 @@ class AttemptRequest(BaseModel):
     evaluation: dict[str, object]
     score: int
     focus_area: str | None = None
+
+
+class FocusAreaRequest(BaseModel):
+    name: str
+    questions: list[str]
+
+
+class DraftRequest(BaseModel):
+    goal: str
+    focus_areas: list[FocusAreaRequest]
+
+
+class DraftResponse(BaseModel):
+    draft_id: str
+    review_url: str

--- a/core/context_import/draft_store.py
+++ b/core/context_import/draft_store.py
@@ -1,0 +1,54 @@
+import json
+import time
+import uuid
+from pathlib import Path
+
+from .parser import ImportedContext
+
+
+class DraftStore:
+    def __init__(self, store_dir: Path, ttl_hours: int = 24):
+        self.drafts_dir = store_dir / "drafts"
+        self.drafts_dir.mkdir(parents=True, exist_ok=True)
+        self.ttl_seconds = ttl_hours * 3600
+
+    def save(self, context_name: str, imported: ImportedContext) -> str:
+        draft_id = str(uuid.uuid4())
+        file_path = self.drafts_dir / f"{draft_id}.json"
+
+        data = {
+            "context_name": context_name,
+            "created_at": time.time(),
+            "goal": imported.goal,
+            "questions": imported.questions,
+        }
+
+        with open(file_path, "w") as f:
+            json.dump(data, f, indent=2)
+
+        return draft_id
+
+    def load(self, context_name: str, draft_id: str) -> ImportedContext | None:
+        # Basic validation to prevent path traversal
+        if not draft_id or not all(c.isalnum() or c == "-" for c in draft_id):
+            return None
+
+        file_path = self.drafts_dir / f"{draft_id}.json"
+        if not file_path.exists():
+            return None
+
+        with open(file_path) as f:
+            data = json.load(f)
+
+        # Validate context name match
+        if data.get("context_name") != context_name:
+            return None
+
+        # Expire old drafts
+        if time.time() - data.get("created_at", 0) > self.ttl_seconds:
+            file_path.unlink(missing_ok=True)
+            return None
+
+        # JSON loads tuples as lists, convert back to tuple for ImportedContext
+        questions = [(item[0], item[1]) for item in data["questions"]]
+        return ImportedContext(goal=data["goal"], questions=questions)

--- a/tests/test_api_draft.py
+++ b/tests/test_api_draft.py
@@ -1,0 +1,81 @@
+from collections.abc import Generator
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.context_import.draft_store import DraftStore
+
+
+def _make_client(store_dir: Path) -> Generator[TestClient]:
+    with ExitStack() as stack:
+        stack.enter_context(patch("api.main.SentenceTransformerEmbedder"))
+        stack.enter_context(patch("api.main.AsyncAnthropic"))
+        stack.enter_context(patch("api.main.genai"))
+        stack.enter_context(patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}))
+        c = TestClient(app)
+        c.app.state.store_dir = store_dir  # type: ignore[attr-defined]
+        c.app.state.draft_store = DraftStore(store_dir)  # type: ignore[attr-defined]
+        yield c
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Generator[TestClient]:
+    yield from _make_client(tmp_path)
+
+
+def test_post_draft_creates_draft_and_returns_url(client: TestClient) -> None:
+    payload = {"goal": "Test goal", "focus_areas": [{"name": "Area 1", "questions": ["Q1", "Q2"]}]}
+    response = client.post("/api/contexts/test-context/draft", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "draft_id" in data
+    assert "review_url" in data
+    assert data["review_url"] == f"/ui/test-context/review/{data['draft_id']}"
+
+
+def test_get_review_renders_template(client: TestClient) -> None:
+    # First create a draft
+    payload = {"goal": "Test goal", "focus_areas": [{"name": "Area 1", "questions": ["Q1", "Q2"]}]}
+    draft_res = client.post("/api/contexts/test-context/draft", json=payload)
+    draft_id = draft_res.json()["draft_id"]
+
+    # Then get the review page
+    response = client.get(f"/ui/test-context/review/{draft_id}")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Test goal" in response.text
+    assert "Area 1" in response.text
+    assert "Q1" in response.text
+
+
+def test_get_review_nonexistent_returns_404(client: TestClient) -> None:
+    response = client.get("/ui/test-context/review/nonexistent")
+    assert response.status_code == 404
+
+
+def test_get_review_invalid_id_returns_404(client: TestClient) -> None:
+    # Tests that IDs failing the whitelist also 404 cleanly via API
+    response = client.get("/ui/test-context/review/../etc")
+    assert response.status_code == 404
+
+
+def test_get_review_wrong_context_returns_404(client: TestClient) -> None:
+    payload = {"goal": "g", "focus_areas": []}
+    draft_res = client.post("/api/contexts/test-context/draft", json=payload)
+    draft_id = draft_res.json()["draft_id"]
+
+    # Try to load the draft for a different context
+    response = client.get(f"/ui/other-context/review/{draft_id}")
+    assert response.status_code == 404
+
+
+def test_post_draft_invalid_context_name_returns_422(client: TestClient) -> None:
+    payload = {"goal": "g", "focus_areas": []}
+    response = client.post("/api/contexts/invalid name/draft", json=payload)
+    assert response.status_code == 422

--- a/tests/test_draft_store.py
+++ b/tests/test_draft_store.py
@@ -1,0 +1,49 @@
+import time
+from pathlib import Path
+
+from core.context_import.draft_store import DraftStore
+from core.context_import.parser import ImportedContext
+
+
+def test_draft_store_save_and_load(tmp_path: Path) -> None:
+    store = DraftStore(tmp_path)
+    imported = ImportedContext(
+        goal="Learn stuff", questions=[("Area 1", ["Q1", "Q2"]), ("Area 2", ["Q3"])]
+    )
+
+    draft_id = store.save("test-ctx", imported)
+    assert draft_id
+
+    loaded = store.load("test-ctx", draft_id)
+    assert loaded is not None
+    assert loaded.goal == "Learn stuff"
+    assert loaded.questions == [("Area 1", ["Q1", "Q2"]), ("Area 2", ["Q3"])]
+
+
+def test_draft_store_load_wrong_context_returns_none(tmp_path: Path) -> None:
+    store = DraftStore(tmp_path)
+    imported = ImportedContext(goal="g", questions=[])
+    draft_id = store.save("test-ctx", imported)
+
+    assert store.load("other-ctx", draft_id) is None
+
+
+def test_draft_store_expiration(tmp_path: Path) -> None:
+    store = DraftStore(tmp_path, ttl_hours=0)  # Expire immediately
+    imported = ImportedContext(goal="g", questions=[])
+    draft_id = store.save("test-ctx", imported)
+
+    time.sleep(0.01)  # Ensure some time passed
+    assert store.load("test-ctx", draft_id) is None
+
+
+def test_draft_store_load_missing_returns_none(tmp_path: Path) -> None:
+    store = DraftStore(tmp_path)
+    assert store.load("test-ctx", "non-existent") is None
+
+
+def test_draft_store_load_invalid_id_returns_none(tmp_path: Path) -> None:
+    store = DraftStore(tmp_path)
+    # Testing that it handles basic path traversal attempts
+    assert store.load("test-ctx", "../secrets") is None
+    assert store.load("test-ctx", "") is None

--- a/tests/test_mcp_create_context.py
+++ b/tests/test_mcp_create_context.py
@@ -1,0 +1,59 @@
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from adapters.mcp.server import create_context
+
+
+@pytest.fixture()
+def mock_client() -> Generator[MagicMock]:
+    with patch("httpx.AsyncClient") as MockClient:
+        mock = MockClient.return_value
+        mock.__aenter__.return_value = mock
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_create_context_success(mock_client: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "draft_id": "d123",
+        "review_url": "/ui/test-context/review/d123",
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    result = await create_context(
+        name="test-context", goal="Test goal", focus_areas=[{"name": "Area 1", "questions": ["Q1"]}]
+    )
+
+    assert "Draft created!" in result
+    assert "/ui/test-context/review/d123" in result
+
+
+@pytest.mark.asyncio
+async def test_create_context_validation_error(mock_client: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 422
+    mock_response.json.return_value = {"detail": "Context name must be at least 4 characters"}
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Unprocessable Entity", request=MagicMock(), response=mock_response
+    )
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    result = await create_context(name="abc", goal="too short", focus_areas=[])
+
+    assert "Validation error:" in result
+    assert "at least 4 characters" in result
+
+
+@pytest.mark.asyncio
+async def test_create_context_api_error(mock_client: MagicMock) -> None:
+    mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
+
+    result = await create_context(name="test", goal="goal", focus_areas=[])
+
+    assert "Error connecting to API" in result


### PR DESCRIPTION
## Problem
Setting up a new learning context from Claude Desktop requires leaving the chat, copying a prompt, running it in another chat, and pasting the response back into the web UI.

## Solution
Add a `create_context` MCP tool that accepts structured parameters (name, goal, focus_areas with questions), POSTs to a new draft endpoint, and returns a link to the existing import review page where the user can edit and confirm. No LLM required server-side.

## Changes
- **DraftStore**: `core/context_import/draft_store.py` for ephemeral storage of context drafts.
- **Draft API**: `POST /api/contexts/{name}/draft` to create drafts from structured data.
- **Review Route**: `GET /ui/{context}/review/{draft_id}` to render the import review UI for a draft.
- **MCP Tool**: `create_context` tool in `adapters/mcp/server.py`.

## Verification
- Unit tests for `DraftStore`.
- Integration tests for API endpoints (`POST /draft`, `GET /review`).
- Unit tests for MCP tool with mocked HTTP.
- All tests passing with `make test`.
