### PR TITLE
feat: show learning context goals on the home page (#218)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -111,9 +111,17 @@ def _get_bank_store(
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def get_index(request: Request) -> HTMLResponse:
     store_dir: Path = request.app.state.store_dir
-    contexts = (
-        sorted(p.name for p in store_dir.iterdir() if p.is_dir()) if store_dir.exists() else []
-    )
+    context_store: ContextStore = request.app.state.context_store
+    contexts: list[dict[str, str | None]] = []
+    if store_dir.exists():
+        names = sorted(p.name for p in store_dir.iterdir() if p.is_dir())
+        metas = await asyncio.gather(
+            *[asyncio.to_thread(context_store.load_context, name) for name in names]
+        )
+        contexts = [
+            {"name": name, "goal": meta.goal if meta else None}
+            for name, meta in zip(names, metas, strict=True)
+        ]
     return templates.TemplateResponse(request, "index.html", {"contexts": contexts})
 
 

--- a/api/static/style.css
+++ b/api/static/style.css
@@ -257,6 +257,44 @@ button.thumb-down:hover {
   color: #ffffff;
 }
 
+/* --- Context list (home page) --- */
+
+.context-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.context-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 2px solid var(--secondary);
+  border-radius: 6px;
+  padding: 16px 20px;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.context-card:hover {
+  background: var(--secondary);
+  color: #ffffff;
+}
+
+.context-card:hover .card-goal {
+  color: #ffffff;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.card-goal {
+  font-size: 13px;
+  color: var(--muted);
+}
+
 /* --- Setup page --- */
 
 .setup-panels {

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -11,9 +11,12 @@
   <body>
     <h1>Learning Tool</h1>
     {% if contexts %}
-    <div class="focus-areas">
+    <div class="context-list">
       {% for ctx in contexts %}
-      <a class="focus-area" href="/ui/{{ ctx | urlencode }}">{{ ctx }}</a>
+      <a class="context-card" href="/ui/{{ ctx.name | urlencode }}">
+        <span class="card-title">{{ ctx.name }}</span>
+        <span class="card-goal">{% if ctx.goal %}{{ ctx.goal }}{% else %}No goal set{% endif %}</span>
+      </a>
       {% endfor %}
     </div>
     {% else %}

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 from fastapi.testclient import TestClient
 
 from api.main import app
+from core.ingestion.store import ContextStore
 
 
 def _make_client(store_dir: Path) -> Generator[TestClient]:
@@ -18,6 +20,7 @@ def _make_client(store_dir: Path) -> Generator[TestClient]:
         stack.enter_context(patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}))
         c = stack.enter_context(TestClient(app))
         c.app.state.store_dir = store_dir  # type: ignore[attr-defined]
+        c.app.state.context_store = ContextStore(store_dir)  # type: ignore[attr-defined]
         yield c
 
 
@@ -25,6 +28,10 @@ def _make_client(store_dir: Path) -> Generator[TestClient]:
 def client(tmp_path: Path) -> Generator[TestClient]:
     (tmp_path / "python").mkdir()
     (tmp_path / "sql").mkdir()
+    (tmp_path / "python" / "context.yaml").write_text(
+        yaml.dump({"goal": "Master Python fundamentals", "focus_areas": []})
+    )
+    # sql has no context.yaml — exercises the missing-yaml path
     yield from _make_client(tmp_path)
 
 
@@ -70,3 +77,16 @@ def test_get_index_missing_store_dir_shows_no_contexts(missing_store_client: Tes
 
     assert response.status_code == 200
     assert "/ui/" not in response.text
+
+
+def test_get_index_shows_context_goal(client: TestClient) -> None:
+    response = client.get("/")
+
+    assert "Master Python fundamentals" in response.text
+
+
+def test_get_index_missing_yaml_shows_placeholder(client: TestClient) -> None:
+    response = client.get("/")
+
+    # sql has no context.yaml — a placeholder should appear instead of the goal text
+    assert "No goal set" in response.text


### PR DESCRIPTION
Closes #218

## Summary
- `GET /` now loads `ContextMetadata` via `context_store.load_context` for each context directory and passes `[{name, goal}]` to the template
- Home page renders each context as a card with name + goal text; shows "No goal set" placeholder when `context.yaml` is absent
- New CSS classes: `.context-list`, `.context-card`, `.card-title`, `.card-goal`

## Test plan
- [ ] `uv run pytest tests/test_api_index.py` — all 7 tests pass, including new tests for goal text and missing-yaml placeholder
- [ ] Full suite passes: `make checks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)