### PR TITLE
chore: block git commits directly to main in pre-commit hook

### DIFF
--- a/.claude/hooks/pre-commit-checks.sh
+++ b/.claude/hooks/pre-commit-checks.sh
@@ -13,6 +13,12 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 PROJECT_ROOT=$(git -C "${CLAUDE_PROJECT_DIR:-.}" rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$PROJECT_ROOT" || exit 0
 
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    echo "ERROR: Do not commit directly to main. Create a feature branch first." >&2
+    exit 2
+fi
+
 ERRORS=""
 OUTPUT=""
 


### PR DESCRIPTION
## Summary
- Adds a branch guard to `.claude/hooks/pre-commit-checks.sh` that blocks `git commit` when on `main`
- Claude Code's `PreToolUse` hook fires before any Bash command matching `git commit`, checks the current branch, and exits with code 2 (blocking error) if it's `main`

## Test plan
- [ ] Attempt `git commit` while on `main` — should be blocked with `ERROR: Do not commit directly to main. Create a feature branch first.`
- [ ] Commit on a feature branch — should proceed normally through lint/mypy checks