### PR TITLE
Add new context widget to home page (#221)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -134,6 +134,25 @@ async def get_index(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(request, "index.html", {"contexts": contexts})
 
 
+@app.get("/ui/_new-context-form", response_class=HTMLResponse, include_in_schema=False)
+async def get_new_context_form(request: Request) -> HTMLResponse:
+    return templates.TemplateResponse(request, "_new_context_form.html")
+
+
+@app.post("/ui/contexts", response_class=HTMLResponse, include_in_schema=False)
+async def post_contexts(request: Request, name: str = Form(...)) -> HTMLResponse:
+    try:
+        validate_context_name(name)
+    except ValueError as e:
+        return templates.TemplateResponse(
+            request,
+            "_new_context_form.html",
+            {"error": str(e)},
+            status_code=400,
+        )
+    return HTMLResponse(headers={"HX-Redirect": f"/ui/{name}/setup"})
+
+
 @app.get("/ui/{context_name}", response_class=HTMLResponse, include_in_schema=False)
 async def get_ui(request: Request, context_name: str, query: str | None = None) -> HTMLResponse:
     if query is None:

--- a/api/static/style.css
+++ b/api/static/style.css
@@ -414,3 +414,9 @@ pre.yaml-block {
   color: var(--primary);
   margin-left: 8px;
 }
+
+.error {
+  color: var(--primary);
+  font-size: 14px;
+  margin-left: 8px;
+}

--- a/api/templates/_new_context_form.html
+++ b/api/templates/_new_context_form.html
@@ -1,0 +1,10 @@
+<div id="new-context-widget">
+  <form hx-post="/ui/contexts" hx-target="#new-context-widget" hx-swap="outerHTML">
+    <input type="text" name="name" placeholder="context-name" autofocus required />
+    <button type="submit">Create</button>
+    <button type="button" hx-get="/" hx-select="#new-context-widget" hx-target="#new-context-widget" hx-swap="outerHTML">cancel</button>
+    {% if error %}
+    <span class="error">{{ error }}</span>
+    {% endif %}
+  </form>
+</div>

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap" />
     <link rel="stylesheet" href="/static/style.css" />
+    <script src="https://unpkg.com/htmx.org@2.0.4" defer></script>
   </head>
   <body>
     <h1>Learning Tool</h1>
@@ -22,6 +23,9 @@
     {% else %}
     <p class="muted">No contexts found.</p>
     {% endif %}
+    <div id="new-context-widget">
+      <button hx-get="/ui/_new-context-form" hx-target="#new-context-widget" hx-swap="outerHTML">+ New context</button>
+    </div>
     <a class="muted" href="/admin">admin</a>
   </body>
 </html>

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -69,14 +69,14 @@ def test_get_index_empty_store_shows_no_contexts(empty_store_client: TestClient)
     response = empty_store_client.get("/")
 
     assert response.status_code == 200
-    assert "/ui/" not in response.text
+    assert "context-card" not in response.text
 
 
 def test_get_index_missing_store_dir_shows_no_contexts(missing_store_client: TestClient) -> None:
     response = missing_store_client.get("/")
 
     assert response.status_code == 200
-    assert "/ui/" not in response.text
+    assert "context-card" not in response.text
 
 
 def test_get_index_shows_context_goal(client: TestClient) -> None:
@@ -90,3 +90,15 @@ def test_get_index_missing_yaml_shows_placeholder(client: TestClient) -> None:
 
     # sql has no context.yaml — a placeholder should appear instead of the goal text
     assert "No goal set" in response.text
+
+
+def test_get_index_shows_new_context_widget(client: TestClient) -> None:
+    response = client.get("/")
+
+    assert 'id="new-context-widget"' in response.text
+
+
+def test_get_index_new_context_button_has_htmx_attributes(client: TestClient) -> None:
+    response = client.get("/")
+
+    assert 'hx-get="/ui/_new-context-form"' in response.text

--- a/tests/test_api_new_context.py
+++ b/tests/test_api_new_context.py
@@ -1,0 +1,81 @@
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient]:
+    with (
+        patch("api.main.SentenceTransformerEmbedder"),
+        patch("api.main.AsyncAnthropic"),
+        patch("api.main.genai"),
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        TestClient(app, follow_redirects=False) as c,
+    ):
+        yield c
+
+
+# --- POST /ui/contexts ---
+
+
+def test_post_contexts_valid_name_returns_hx_redirect(client: TestClient) -> None:
+    response = client.post("/ui/contexts", data={"name": "my-context"})
+
+    assert response.headers.get("HX-Redirect") == "/ui/my-context/setup"
+
+
+def test_post_contexts_valid_name_returns_200(client: TestClient) -> None:
+    response = client.post("/ui/contexts", data={"name": "my-context"})
+
+    assert response.status_code == 200
+
+
+def test_post_contexts_invalid_name_returns_400(client: TestClient) -> None:
+    response = client.post("/ui/contexts", data={"name": "NO"})
+
+    assert response.status_code == 400
+
+
+def test_post_contexts_invalid_name_returns_error_in_body(client: TestClient) -> None:
+    response = client.post("/ui/contexts", data={"name": "NO"})
+
+    assert 'class="error"' in response.text
+    assert "at least" in response.text
+
+
+def test_post_contexts_invalid_name_returns_form_fragment(client: TestClient) -> None:
+    response = client.post("/ui/contexts", data={"name": "NO"})
+
+    assert "text/html" in response.headers["content-type"]
+    assert "form" in response.text.lower() or "input" in response.text.lower()
+
+
+# --- GET /ui/_new-context-form ---
+
+
+def test_get_new_context_form_returns_200(client: TestClient) -> None:
+    response = client.get("/ui/_new-context-form")
+
+    assert response.status_code == 200
+
+
+def test_get_new_context_form_returns_html(client: TestClient) -> None:
+    response = client.get("/ui/_new-context-form")
+
+    assert "text/html" in response.headers["content-type"]
+
+
+def test_get_new_context_form_contains_form(client: TestClient) -> None:
+    response = client.get("/ui/_new-context-form")
+
+    assert "<form" in response.text
+
+
+def test_get_new_context_form_posts_to_correct_target(client: TestClient) -> None:
+    response = client.get("/ui/_new-context-form")
+
+    assert 'hx-post="/ui/contexts"' in response.text or 'action="/ui/contexts"' in response.text


### PR DESCRIPTION
Closes #221

## Changes

- `POST /ui/contexts` — validates context name via `validate_context_name`; returns `HX-Redirect` to `/ui/{name}/setup` on success, or re-renders `_new_context_form.html` with an inline error (400) on failure
- `GET /ui/_new-context-form` — returns the form fragment for HTMX swap
- `_new_context_form.html` — form with name input, submit, and cancel (cancel uses `hx-get="/"` + `hx-select` to pull the button back without a second fragment endpoint)
- `index.html` — button area wrapped in `<div id="new-context-widget">` with HTMX attributes; htmx script added to head

## Test plan

- [ ] All checks pass (`ruff check`, `ruff format --check`, `mypy`, `pytest` — 371 passed)
- [ ] `POST /ui/contexts` with valid name returns `HX-Redirect` header
- [ ] `POST /ui/contexts` with invalid name returns 400 + form with error
- [ ] `GET /ui/_new-context-form` returns 200 with form posting to `/ui/contexts`
- [ ] Home page shows `#new-context-widget` div with htmx button

🤖 Generated with [Claude Code](https://claude.com/claude-code)