### PR TITLE
feat: edit and delete contexts from home page (#220)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -121,15 +121,16 @@ def _get_bank_store(
 async def get_index(request: Request) -> HTMLResponse:
     store_dir: Path = request.app.state.store_dir
     context_store: ContextStore = request.app.state.context_store
-    contexts: list[dict[str, str | None]] = []
+    contexts: list[dict[str, str]] = []
     if store_dir.exists():
         names = sorted(p.name for p in store_dir.iterdir() if p.is_dir())
         metas = await asyncio.gather(
             *[asyncio.to_thread(context_store.load_context, name) for name in names]
         )
         contexts = [
-            {"name": name, "goal": meta.goal if meta else None}
+            {"name": name, "goal": meta.goal}
             for name, meta in zip(names, metas, strict=True)
+            if meta is not None and not meta.archived
         ]
     return templates.TemplateResponse(request, "index.html", {"contexts": contexts})
 

--- a/api/main.py
+++ b/api/main.py
@@ -140,6 +140,18 @@ async def get_new_context_form(request: Request) -> HTMLResponse:
     return templates.TemplateResponse(request, "_new_context_form.html")
 
 
+@app.post(
+    "/ui/contexts/{context_name}/archive", response_class=HTMLResponse, include_in_schema=False
+)
+async def post_archive_context(request: Request, context_name: str) -> Response:
+    context_store: ContextStore = request.app.state.context_store
+    try:
+        await asyncio.to_thread(context_store.archive_context, context_name)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    return Response(status_code=200)
+
+
 @app.post("/ui/contexts", response_class=HTMLResponse, include_in_schema=False)
 async def post_contexts(request: Request, name: str = Form(...)) -> HTMLResponse:
     try:

--- a/api/static/style.css
+++ b/api/static/style.css
@@ -265,7 +265,14 @@ button.thumb-down:hover {
   gap: 12px;
 }
 
+.context-card-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .context-card {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -274,6 +281,12 @@ button.thumb-down:hover {
   padding: 16px 20px;
   text-decoration: none;
   color: var(--text);
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .context-card:hover {

--- a/api/templates/_context_card.html
+++ b/api/templates/_context_card.html
@@ -1,0 +1,13 @@
+<div id="context-card-{{ ctx.name }}" class="context-card-wrapper">
+  <a class="context-card" href="/ui/{{ ctx.name | urlencode }}">
+    <span class="card-title">{{ ctx.name }}</span>
+    <span class="card-goal">{{ ctx.goal }}</span>
+  </a>
+  <div class="card-actions">
+    <a href="/ui/{{ ctx.name | urlencode }}/setup">edit</a>
+    <button hx-post="/ui/contexts/{{ ctx.name | urlencode }}/archive"
+            hx-target="#context-card-{{ ctx.name }}"
+            hx-swap="delete"
+            hx-confirm="Archive {{ ctx.name }}?">archive</button>
+  </div>
+</div>

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -14,10 +14,7 @@
     {% if contexts %}
     <div class="context-list">
       {% for ctx in contexts %}
-      <a class="context-card" href="/ui/{{ ctx.name | urlencode }}">
-        <span class="card-title">{{ ctx.name }}</span>
-        <span class="card-goal">{% if ctx.goal %}{{ ctx.goal }}{% else %}No goal set{% endif %}</span>
-      </a>
+      {% include "_context_card.html" %}
       {% endfor %}
     </div>
     {% else %}

--- a/core/ingestion/store.py
+++ b/core/ingestion/store.py
@@ -24,6 +24,13 @@ class ContextStore:
             yaml.dump(metadata.model_dump(), default_flow_style=False)
         )
 
+    def archive_context(self, context: str) -> None:
+        meta = self.load_context(context)
+        if meta is None:
+            raise FileNotFoundError(f"No context found for '{context}'")
+        meta = meta.model_copy(update={"archived": True})
+        self.save_context(context, meta)
+
     def load_context(self, context: str) -> ContextMetadata | None:
         ctx_file = self.base_dir / context / "context.yaml"
         if not ctx_file.exists():

--- a/core/models.py
+++ b/core/models.py
@@ -12,8 +12,9 @@ class UserProfile:
 
 
 class ContextMetadata(BaseModel):
-    goal: str
+    goal: Annotated[str, Field(min_length=1)]
     focus_areas: list[str]
+    archived: bool = False
 
 
 class Question(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from collections.abc import Generator
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.ingestion.store import ContextStore
+
+
+def make_api_client(store_dir: Path) -> Generator[TestClient]:
+    """Yield a TestClient with heavy dependencies mocked and store wired to store_dir."""
+    with ExitStack() as stack:
+        stack.enter_context(patch("api.main.SentenceTransformerEmbedder"))
+        stack.enter_context(patch("api.main.AsyncAnthropic"))
+        stack.enter_context(patch("api.main.genai"))
+        stack.enter_context(patch("api.main.SessionStore"))
+        stack.enter_context(patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}))
+        c = stack.enter_context(TestClient(app))
+        c.app.state.store_dir = store_dir  # type: ignore[attr-defined]
+        c.app.state.context_store = ContextStore(store_dir)  # type: ignore[attr-defined]
+        yield c

--- a/tests/test_api_archive_context.py
+++ b/tests/test_api_archive_context.py
@@ -1,0 +1,50 @@
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from core.ingestion.store import ContextStore
+from tests.conftest import make_api_client
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Generator[TestClient]:
+    (tmp_path / "my-context").mkdir()
+    (tmp_path / "my-context" / "context.yaml").write_text(
+        yaml.dump({"goal": "Learn Python basics", "focus_areas": []})
+    )
+    yield from make_api_client(tmp_path)
+
+
+# --- POST /ui/contexts/{name}/archive ---
+
+
+def test_post_archive_returns_200(client: TestClient) -> None:
+    # Must be 200 (not 204) — HTMX 2.x ignores 204 responses entirely,
+    # so hx-swap="delete" would not fire.
+    response = client.post("/ui/contexts/my-context/archive")
+
+    assert response.status_code == 200
+
+
+def test_post_archive_returns_empty_response(client: TestClient) -> None:
+    response = client.post("/ui/contexts/my-context/archive")
+
+    assert response.text.strip() == ""
+
+
+def test_post_archive_sets_archived_in_store(client: TestClient, tmp_path: Path) -> None:
+    client.post("/ui/contexts/my-context/archive")
+
+    store = ContextStore(tmp_path)
+    loaded = store.load_context("my-context")
+    assert loaded is not None
+    assert loaded.archived is True
+
+
+def test_post_archive_missing_context_returns_404(client: TestClient) -> None:
+    response = client.post("/ui/contexts/no-such-context/archive")
+
+    assert response.status_code == 404

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -1,27 +1,11 @@
 from collections.abc import Generator
-from contextlib import ExitStack
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import yaml
 from fastapi.testclient import TestClient
 
-from api.main import app
-from core.ingestion.store import ContextStore
-
-
-def _make_client(store_dir: Path) -> Generator[TestClient]:
-    with ExitStack() as stack:
-        stack.enter_context(patch("api.main.SentenceTransformerEmbedder"))
-        stack.enter_context(patch("api.main.AsyncAnthropic"))
-        stack.enter_context(patch("api.main.genai"))
-        stack.enter_context(patch("api.main.SessionStore"))
-        stack.enter_context(patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}))
-        c = stack.enter_context(TestClient(app))
-        c.app.state.store_dir = store_dir  # type: ignore[attr-defined]
-        c.app.state.context_store = ContextStore(store_dir)  # type: ignore[attr-defined]
-        yield c
+from tests.conftest import make_api_client
 
 
 @pytest.fixture()
@@ -32,17 +16,17 @@ def client(tmp_path: Path) -> Generator[TestClient]:
         yaml.dump({"goal": "Master Python fundamentals", "focus_areas": []})
     )
     # sql has no context.yaml — exercises the missing-yaml path
-    yield from _make_client(tmp_path)
+    yield from make_api_client(tmp_path)
 
 
 @pytest.fixture()
 def empty_store_client(tmp_path: Path) -> Generator[TestClient]:
-    yield from _make_client(tmp_path)
+    yield from make_api_client(tmp_path)
 
 
 @pytest.fixture()
 def missing_store_client(tmp_path: Path) -> Generator[TestClient]:
-    yield from _make_client(tmp_path / "nonexistent")
+    yield from make_api_client(tmp_path / "nonexistent")
 
 
 def test_get_index_returns_200(client: TestClient) -> None:
@@ -116,7 +100,7 @@ def archived_store_client(tmp_path: Path) -> Generator[TestClient]:
     (tmp_path / "archived-ctx" / "context.yaml").write_text(
         yaml.dump({"goal": "archived goal", "focus_areas": [], "archived": True})
     )
-    yield from _make_client(tmp_path)
+    yield from make_api_client(tmp_path)
 
 
 def test_get_index_excludes_archived_contexts(archived_store_client: TestClient) -> None:

--- a/tests/test_api_index.py
+++ b/tests/test_api_index.py
@@ -55,8 +55,10 @@ def test_get_index_returns_200(client: TestClient) -> None:
 def test_get_index_lists_context_links(client: TestClient) -> None:
     response = client.get("/")
 
+    # python has a context.yaml — should appear
     assert "/ui/python" in response.text
-    assert "/ui/sql" in response.text
+    # sql has no context.yaml — should be hidden
+    assert "/ui/sql" not in response.text
 
 
 def test_get_index_links_to_admin(client: TestClient) -> None:
@@ -85,11 +87,11 @@ def test_get_index_shows_context_goal(client: TestClient) -> None:
     assert "Master Python fundamentals" in response.text
 
 
-def test_get_index_missing_yaml_shows_placeholder(client: TestClient) -> None:
+def test_get_index_missing_yaml_not_shown(client: TestClient) -> None:
     response = client.get("/")
 
-    # sql has no context.yaml — a placeholder should appear instead of the goal text
-    assert "No goal set" in response.text
+    # sql has no context.yaml — should be hidden entirely, not shown with placeholder
+    assert "No goal set" not in response.text
 
 
 def test_get_index_shows_new_context_widget(client: TestClient) -> None:
@@ -102,3 +104,23 @@ def test_get_index_new_context_button_has_htmx_attributes(client: TestClient) ->
     response = client.get("/")
 
     assert 'hx-get="/ui/_new-context-form"' in response.text
+
+
+@pytest.fixture()
+def archived_store_client(tmp_path: Path) -> Generator[TestClient]:
+    (tmp_path / "active").mkdir()
+    (tmp_path / "archived-ctx").mkdir()
+    (tmp_path / "active" / "context.yaml").write_text(
+        yaml.dump({"goal": "active goal", "focus_areas": [], "archived": False})
+    )
+    (tmp_path / "archived-ctx" / "context.yaml").write_text(
+        yaml.dump({"goal": "archived goal", "focus_areas": [], "archived": True})
+    )
+    yield from _make_client(tmp_path)
+
+
+def test_get_index_excludes_archived_contexts(archived_store_client: TestClient) -> None:
+    response = archived_store_client.get("/")
+
+    assert "active goal" in response.text
+    assert "archived goal" not in response.text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,9 @@
 import uuid
 
-from core.models import Question
+import pytest
+from pydantic import ValidationError
+
+from core.models import ContextMetadata, Question
 
 
 def test_question_auto_generates_valid_uuid() -> None:
@@ -12,3 +15,8 @@ def test_question_ids_are_unique() -> None:
     q1 = Question(text="x")
     q2 = Question(text="x")
     assert q1.question_id != q2.question_id
+
+
+def test_context_metadata_rejects_empty_goal() -> None:
+    with pytest.raises(ValidationError):
+        ContextMetadata(goal="", focus_areas=[])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import yaml
 
 from core.ingestion.store import ChunkStore, ContextStore
 from core.models import ContextMetadata
@@ -67,6 +68,30 @@ def test_load_missing_context_raises(tmp_path: Path) -> None:
     store = ChunkStore(tmp_path)
     with pytest.raises(FileNotFoundError):
         store.load("does-not-exist")
+
+
+def test_load_context_without_archived_field_defaults_to_false(tmp_path: Path) -> None:
+    store = ContextStore(tmp_path)
+    ctx_dir = tmp_path / "myctx"
+    ctx_dir.mkdir()
+    (ctx_dir / "context.yaml").write_text(yaml.dump({"goal": "some goal", "focus_areas": []}))
+
+    loaded = store.load_context("myctx")
+
+    assert loaded is not None
+    assert loaded.archived is False
+
+
+def test_archive_context_sets_archived_true(tmp_path: Path) -> None:
+    store = ContextStore(tmp_path)
+    metadata = ContextMetadata(goal="some goal", focus_areas=[])
+    store.save_context("ctx", metadata)
+
+    store.archive_context("ctx")
+    loaded = store.load_context("ctx")
+
+    assert loaded is not None
+    assert loaded.archived is True
 
 
 def test_different_contexts_are_isolated(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #220

## Summary

- Adds `archived: bool = False` to `ContextMetadata` (backward compatible — existing YAML files without the field parse correctly)
- Adds `archive_context` method to `ContextStore`
- Filters archived and unconfigured contexts from `GET /` — only contexts with a valid `context.yaml` and `archived: false` appear on the home page
- New endpoint: `POST /ui/contexts/{name}/archive` — soft-deletes the context (sets `archived: true`), returns 200 so HTMX's `hx-swap="delete"` removes the card from the DOM without a reload
- Context cards now have two actions to the right of the card: **edit** (links to `/ui/{name}/setup` for re-import) and **archive** (inline confirm, then card removed from DOM)
- `ContextMetadata.goal` now requires `min_length=1`

## Test plan

- [ ] Context cards show edit and archive buttons to the right of the card
- [ ] Edit navigates to the setup/re-import page for that context
- [ ] Archive shows a confirm dialog; on confirm the card disappears immediately (no reload)
- [ ] Archived context no longer appears after page reload
- [ ] Contexts without a `context.yaml` no longer appear on the home page
- [ ] `uv run pytest` — 379 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)