### PR TITLE
fix: coerce string evaluation fields to list at API boundary (#242)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -537,6 +537,9 @@ async def get_session_results(request: Request, context_name: str, session_id: s
         if a.result_json:
             try:
                 result = json.loads(a.result_json)
+                for _f in ("strengths", "gaps", "missing_points"):
+                    if isinstance(result.get(_f), str):
+                        result[_f] = [result[_f]]
             except json.JSONDecodeError:
                 logger.warning("malformed result_json for attempt in session %s", session_id)
         attempts.append({"attempt": a, "result": result})
@@ -566,6 +569,9 @@ async def get_history(
             if a.result_json:
                 try:
                     result = json.loads(a.result_json)
+                    for _f in ("strengths", "gaps", "missing_points"):
+                        if isinstance(result.get(_f), str):
+                            result[_f] = [result[_f]]
                 except json.JSONDecodeError:
                     logger.warning("malformed result_json for attempt in session %s", s.session_id)
             attempts.append({"attempt": a, "result": result})

--- a/api/main.py
+++ b/api/main.py
@@ -862,7 +862,7 @@ async def post_attempt(body: AttemptRequest) -> dict[str, int]:
         body.answer,
         body.score,
         body.question_id,
-        json.dumps(body.evaluation),
+        body.evaluation.model_dump_json(),
         focus_area=body.focus_area,
     )
     return {"attempt_id": attempt_id}

--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from core.models import EvaluationResult
+
 
 class QuestionResponse(BaseModel):
     text: str
@@ -27,7 +29,7 @@ class AttemptRequest(BaseModel):
     question_id: str
     question: str
     answer: str
-    evaluation: dict[str, object]
+    evaluation: EvaluationResult
     score: int
     focus_area: str | None = None
 

--- a/core/models.py
+++ b/core/models.py
@@ -3,7 +3,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 @dataclass
@@ -29,6 +29,13 @@ class EvaluationResult(BaseModel):
     missing_points: list[str]
     suggested_addition: str | None
     follow_up_question: str
+
+    @field_validator("strengths", "gaps", "missing_points", mode="before")
+    @classmethod
+    def coerce_str_to_list(cls, v: object) -> object:
+        if isinstance(v, str):
+            return [v]
+        return v
 
 
 @dataclass

--- a/core/models.py
+++ b/core/models.py
@@ -34,7 +34,9 @@ class EvaluationResult(BaseModel):
     @classmethod
     def coerce_str_to_list(cls, v: object) -> object:
         if isinstance(v, str):
-            return [v]
+            # Empty string means "nothing here" — treat as empty list so the
+            # template doesn't render a single empty <li>.
+            return [v] if v else []
         return v
 
 

--- a/docs/decisions/017-validate-uncontrolled-llm-input-at-api-boundary.md
+++ b/docs/decisions/017-validate-uncontrolled-llm-input-at-api-boundary.md
@@ -1,0 +1,36 @@
+# ADR 017 — Validate uncontrolled LLM input at the API boundary using the domain model
+
+## Status
+Accepted
+
+## Context
+Issue #242. The MCP `record_attempt` tool accepts `evaluation: dict[str, object]` from
+the caller's LLM. Tool definitions are soft guidance — unlike structured outputs (ADR-006),
+there is no enforcement when an external LLM calls our tool. An LLM can pass
+`"strengths": "Good structure."` (a string) instead of `["Good structure."]` (a list).
+
+`POST /api/attempts` was storing it verbatim via `json.dumps(body.evaluation)`. When the
+history template iterated `{% for s in item.result.strengths %}`, Jinja2 iterated the string
+character-by-character — one `<li>` per character.
+
+## Decision
+- Add a `field_validator` to `EvaluationResult` (`core/models.py`) for `strengths`, `gaps`,
+  and `missing_points` that coerces `str → [str]`. Be lenient at the model boundary for
+  uncontrolled input.
+- Change `AttemptRequest.evaluation` from `dict[str, object]` to `EvaluationResult`
+  (`api/models.py`). This runs validation at the API boundary using the domain model.
+- Store via `body.evaluation.model_dump_json()` instead of `json.dumps(body.evaluation)`.
+
+## Rationale
+Structured outputs (ADR-006) apply only when *we* call the LLM. When an LLM calls *our*
+tool, the API boundary is the only control point. Coercing at the model layer means all
+callers — MCP, direct API, future integrations — get consistent behaviour without
+duplicating the fix.
+
+Using `EvaluationResult` as the request type instead of a loose dict also gives us type
+safety throughout the request handler and makes the expected shape explicit in the API.
+
+## Revisit if
+The evaluation schema evolves in ways that make strict typing at the boundary impractical
+(e.g. provider-specific fields). At that point a dedicated inbound DTO with coercion
+validators separate from the domain model would be the natural split.

--- a/tests/test_api_attempts.py
+++ b/tests/test_api_attempts.py
@@ -41,6 +41,8 @@ def client_no_context() -> Generator[tuple[TestClient, MagicMock]]:
     yield from _make_client(mock_store, store_exists=False)
 
 
+# Fully-populated EvaluationResult — all fields required now that
+# AttemptRequest.evaluation is typed as EvaluationResult, not dict[str, object].
 _VALID_PAYLOAD = {
     "context": "biology",
     "session_id": "sess-abc",
@@ -80,6 +82,7 @@ def test_post_attempt_records_to_session_store(client_ok: tuple[TestClient, Magi
     assert args[2] == "The smallest unit of life."
     assert args[3] == 7
     assert args[4] == "q-123"
+    # model_dump_json() field order is not guaranteed — parse and compare as dict.
     assert json.loads(args[5]) == {
         "score": 7,
         "strengths": ["correct"],

--- a/tests/test_api_attempts.py
+++ b/tests/test_api_attempts.py
@@ -47,7 +47,14 @@ _VALID_PAYLOAD = {
     "question_id": "q-123",
     "question": "What is a cell?",
     "answer": "The smallest unit of life.",
-    "evaluation": {"score": 7, "strengths": ["correct"], "gaps": []},
+    "evaluation": {
+        "score": 7,
+        "strengths": ["correct"],
+        "gaps": [],
+        "missing_points": [],
+        "suggested_addition": None,
+        "follow_up_question": "Can you elaborate?",
+    },
     "score": 7,
 }
 
@@ -73,7 +80,14 @@ def test_post_attempt_records_to_session_store(client_ok: tuple[TestClient, Magi
     assert args[2] == "The smallest unit of life."
     assert args[3] == 7
     assert args[4] == "q-123"
-    assert args[5] == json.dumps({"score": 7, "strengths": ["correct"], "gaps": []})
+    assert json.loads(args[5]) == {
+        "score": 7,
+        "strengths": ["correct"],
+        "gaps": [],
+        "missing_points": [],
+        "suggested_addition": None,
+        "follow_up_question": "Can you elaborate?",
+    }
 
 
 def test_post_attempt_threads_focus_area(client_ok: tuple[TestClient, MagicMock]) -> None:
@@ -111,3 +125,26 @@ def test_post_attempt_404_context_not_found(
 
     assert response.status_code == 404
     assert "not found" in response.json()["detail"]
+
+
+def test_post_attempt_coerces_string_strengths_to_list(
+    client_ok: tuple[TestClient, MagicMock],
+) -> None:
+    client, mock_store = client_ok
+    payload = {
+        **_VALID_PAYLOAD,
+        "evaluation": {
+            "score": 7,
+            "strengths": "Good structure.",
+            "gaps": [],
+            "missing_points": [],
+            "suggested_addition": None,
+            "follow_up_question": "Can you elaborate?",
+        },
+    }
+    response = client.post("/api/attempts", json=payload)
+
+    assert response.status_code == 201
+    call_args = mock_store.record.call_args
+    stored = json.loads(call_args.args[5])
+    assert stored["strengths"] == ["Good structure."]

--- a/tests/test_api_history.py
+++ b/tests/test_api_history.py
@@ -139,6 +139,29 @@ def test_get_history_shows_evaluation_breakdown(client: TestClient) -> None:
     assert "Consider X." in response.text
 
 
+def test_get_history_coerces_string_fields_to_list(client: TestClient) -> None:
+    """Existing DB records may have string values for list fields — coerce on load."""
+    app.state.session_stores = {}
+    app.state.session_stores["my-context"] = MagicMock()
+    result = {
+        "score": 7,
+        "strengths": "Good structure.",
+        "gaps": "Missing context.",
+        "missing_points": "Edge case",
+        "suggested_addition": None,
+        "follow_up_question": None,
+    }
+    app.state.session_stores["my-context"].load_sessions.return_value = [
+        _session([_attempt(result=result)])
+    ]
+
+    response = client.get("/ui/my-context/history")
+
+    assert "Good structure." in response.text
+    assert "Missing context." in response.text
+    assert "Edge case" in response.text
+
+
 def test_get_history_malformed_result_json_falls_back_to_none(client: TestClient) -> None:
     app.state.session_stores = {}
     app.state.session_stores["my-context"] = MagicMock()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
-from core.models import ContextMetadata, Question
+from core.models import ContextMetadata, EvaluationResult, Question
 
 
 def test_question_auto_generates_valid_uuid() -> None:
@@ -20,3 +20,39 @@ def test_question_ids_are_unique() -> None:
 def test_context_metadata_rejects_empty_goal() -> None:
     with pytest.raises(ValidationError):
         ContextMetadata(goal="", focus_areas=[])
+
+
+def test_evaluation_result_coerces_string_strengths_to_list() -> None:
+    result = EvaluationResult(
+        score=7,
+        strengths="Good structure.",  # type: ignore[arg-type]
+        gaps=[],
+        missing_points=[],
+        suggested_addition=None,
+        follow_up_question="What else?",
+    )
+    assert result.strengths == ["Good structure."]
+
+
+def test_evaluation_result_coerces_string_gaps_to_list() -> None:
+    result = EvaluationResult(
+        score=5,
+        strengths=[],
+        gaps="Missed key detail.",  # type: ignore[arg-type]
+        missing_points=[],
+        suggested_addition=None,
+        follow_up_question="Can you elaborate?",
+    )
+    assert result.gaps == ["Missed key detail."]
+
+
+def test_evaluation_result_coerces_string_missing_points_to_list() -> None:
+    result = EvaluationResult(
+        score=4,
+        strengths=[],
+        gaps=[],
+        missing_points="Definition omitted.",  # type: ignore[arg-type]
+        suggested_addition=None,
+        follow_up_question="What did you miss?",
+    )
+    assert result.missing_points == ["Definition omitted."]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,3 +56,17 @@ def test_evaluation_result_coerces_string_missing_points_to_list() -> None:
         follow_up_question="What did you miss?",
     )
     assert result.missing_points == ["Definition omitted."]
+
+
+def test_evaluation_result_coerces_empty_string_to_empty_list() -> None:
+    result = EvaluationResult(
+        score=6,
+        strengths="",  # type: ignore[arg-type]
+        gaps="",  # type: ignore[arg-type]
+        missing_points="",  # type: ignore[arg-type]
+        suggested_addition=None,
+        follow_up_question="Anything else?",
+    )
+    assert result.strengths == []
+    assert result.gaps == []
+    assert result.missing_points == []


### PR DESCRIPTION
## Summary

- Adds `field_validator` to `EvaluationResult` for `strengths`, `gaps`, and `missing_points` that coerces `str → [str]` — handles the case where an LLM passes a string instead of a list
- Tightens `AttemptRequest.evaluation` from `dict[str, object]` to `EvaluationResult` so validation runs at the API boundary using the domain model
- Stores via `model_dump_json()` instead of `json.dumps()` to ensure consistent serialisation

Fixes the history page bug where Jinja2 iterated a string character-by-character, rendering one `<li>` per character.

## Commits

1. `fix: coerce string evaluation fields to list at API boundary` — validator, type change, storage fix, tests
2. `docs: add ADR-017` — documents the decision to validate uncontrolled LLM input at the API boundary

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)