### PR TITLE
fix(ui): fix broken submit button for contexts without a chunk store

### DIFF
--- a/alembic/versions/004_nullable_score.py
+++ b/alembic/versions/004_nullable_score.py
@@ -1,0 +1,36 @@
+"""make attempts.score nullable
+
+Revision ID: f4a9c2e7b813
+Revises: d9c3a7b15e62
+Create Date: 2026-04-11
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a9c2e7b813"
+down_revision: str | None = "d9c3a7b15e62"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    col_info = {
+        row[1]: row[3]
+        for row in bind.execute(sqlalchemy.text("PRAGMA table_info(attempts)")).fetchall()
+    }
+    # notnull=1 means NOT NULL constraint; skip if already nullable
+    if col_info.get("score") == 1:
+        with op.batch_alter_table("attempts") as batch_op:
+            batch_op.alter_column("score", existing_type=sqlalchemy.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    # Reverting to NOT NULL would fail for rows with score=NULL; skip.
+    pass

--- a/api/main.py
+++ b/api/main.py
@@ -388,6 +388,43 @@ async def post_evaluate_fragment(
     )
 
 
+@app.post("/ui/{context_name}/submit", response_class=HTMLResponse, include_in_schema=False)
+async def post_submit_fragment(
+    request: Request,
+    context_name: str,
+    question: str = Form(...),
+    answer: str = Form(...),
+    query: str = Form(...),
+    session_id: str = Form(...),
+    question_id: str | None = Form(default=None),
+) -> HTMLResponse:
+    bank_store = _get_bank_store(app.state.bank_stores, app.state.store_dir, context_name)
+    session_store = _get_session_store(app.state.session_stores, app.state.store_dir, context_name)
+    next_question, _ = await asyncio.gather(
+        asyncio.to_thread(bank_store.get_random, query),
+        asyncio.to_thread(
+            session_store.record, session_id, question, answer, None, question_id, None
+        ),
+    )
+    if next_question is None:
+        return templates.TemplateResponse(
+            request,
+            "bank_empty.html",
+            {"context_name": context_name, "focus_area": query, "session_id": session_id},
+        )
+    return templates.TemplateResponse(
+        request,
+        "question.html",
+        {
+            "context_name": context_name,
+            "question": next_question.question,
+            "question_id": next_question.id,
+            "query": query,
+            "session_id": session_id,
+        },
+    )
+
+
 @app.get("/ui/{context_name}/capture", response_class=HTMLResponse, include_in_schema=False)
 async def get_capture(request: Request, context_name: str) -> HTMLResponse:
     try:

--- a/api/main.py
+++ b/api/main.py
@@ -337,6 +337,9 @@ async def get_question_fragment(
             "question_id": question.question_id,
             "query": query,
             "session_id": session_id,
+            "form_action": f"/ui/{context_name}/evaluate",
+            "skip_path": f"/ui/{context_name}/question",
+            "skip_query_param": "query",
         },
     )
 
@@ -421,6 +424,9 @@ async def post_submit_fragment(
             "question_id": next_question.id,
             "query": query,
             "session_id": session_id,
+            "form_action": f"/ui/{context_name}/submit",
+            "skip_path": f"/ui/{context_name}/question/bank",
+            "skip_query_param": "focus_area",
         },
     )
 
@@ -878,6 +884,9 @@ async def get_bank_question_fragment(
             "question_id": question.id,
             "query": focus_area,
             "session_id": session_id,
+            "form_action": f"/ui/{context_name}/submit",
+            "skip_path": f"/ui/{context_name}/question/bank",
+            "skip_query_param": "focus_area",
         },
     )
 

--- a/api/templates/history.html
+++ b/api/templates/history.html
@@ -30,9 +30,10 @@
         {{ row.session.started_at[:10] }}
         &nbsp;·&nbsp;
         {{ row.attempts | length }} question{{ 's' if row.attempts | length != 1 else '' }}
-        {% if row.attempts %}
+        {% set scored = row.attempts | map(attribute='attempt') | map(attribute='score') | reject('none') | list %}
+        {% if scored %}
         &nbsp;·&nbsp;
-        avg {{ (row.attempts | map(attribute='attempt') | map(attribute='score') | sum / row.attempts | length) | round(1) }}/10
+        avg {{ (scored | sum / scored | length) | round(1) }}/10
         {% endif %}
       </p>
 
@@ -40,7 +41,11 @@
       <div class="attempt-card">
         <p class="attempt-question">{{ item.attempt.question_text }}</p>
         <p class="attempt-answer muted">{{ item.attempt.answer_text }}</p>
+        {% if item.attempt.score is not none %}
         <p class="score">{{ item.attempt.score }}/10</p>
+        {% else %}
+        <p class="score muted">pending</p>
+        {% endif %}
 
         {% if item.result %}
         {% if item.result.strengths %}

--- a/api/templates/question.html
+++ b/api/templates/question.html
@@ -17,7 +17,7 @@
   </div>
 
   <form
-    hx-post="/ui/{{ context_name }}/submit"
+    hx-post="{{ form_action }}"
     hx-target="#question-area"
     hx-swap="outerHTML"
     hx-indicator=".htmx-indicator"
@@ -40,7 +40,7 @@
 
   <button
     class="skip"
-    hx-get="/ui/{{ context_name }}/question/bank?focus_area={{ query | urlencode }}&session_id={{ session_id }}"
+    hx-get="{{ skip_path }}?{{ skip_query_param }}={{ query | urlencode }}&session_id={{ session_id }}"
     hx-target="#question-area"
     hx-swap="outerHTML"
   >Skip</button>

--- a/api/templates/question.html
+++ b/api/templates/question.html
@@ -17,7 +17,7 @@
   </div>
 
   <form
-    hx-post="/ui/{{ context_name }}/evaluate"
+    hx-post="/ui/{{ context_name }}/submit"
     hx-target="#question-area"
     hx-swap="outerHTML"
     hx-indicator=".htmx-indicator"
@@ -35,7 +35,7 @@
     ></textarea>
     <br />
     <button type="submit" class="submit">Submit</button>
-    <span class="htmx-indicator"> Evaluating...</span>
+    <span class="htmx-indicator"> Submitting...</span>
   </form>
 
   <button

--- a/api/templates/question.html
+++ b/api/templates/question.html
@@ -40,7 +40,7 @@
 
   <button
     class="skip"
-    hx-get="/ui/{{ context_name }}/question?query={{ query | urlencode }}&session_id={{ session_id }}"
+    hx-get="/ui/{{ context_name }}/question/bank?focus_area={{ query | urlencode }}&session_id={{ session_id }}"
     hx-target="#question-area"
     hx-swap="outerHTML"
   >Skip</button>

--- a/core/session/models.py
+++ b/core/session/models.py
@@ -6,7 +6,7 @@ class QuestionAttempt:
     session_id: str
     question_text: str
     answer_text: str
-    score: int
+    score: int | None
     timestamp: str
     question_id: str | None = None
     result_json: str | None = None

--- a/core/session/store.py
+++ b/core/session/store.py
@@ -51,7 +51,7 @@ class SessionStore:
         session_id: str,
         question_text: str,
         answer_text: str,
-        score: int,
+        score: int | None,
         question_id: str | None = None,
         result_json: str | None = None,
         focus_area: str | None = None,

--- a/tests/test_api_bank.py
+++ b/tests/test_api_bank.py
@@ -115,3 +115,13 @@ def test_get_bank_question_fragment_generate_button_links_to_generation_endpoint
     )
 
     assert "/ui/myctx/question" in response.text
+
+
+def test_get_bank_question_fragment_form_posts_to_submit(
+    client_with_question: TestClient,
+) -> None:
+    response = client_with_question.get(
+        "/ui/myctx/question/bank?focus_area=Agent+Development&session_id=sess-1"
+    )
+
+    assert "/ui/myctx/submit" in response.text

--- a/tests/test_api_bank.py
+++ b/tests/test_api_bank.py
@@ -117,6 +117,16 @@ def test_get_bank_question_fragment_generate_button_links_to_generation_endpoint
     assert "/ui/myctx/question" in response.text
 
 
+def test_get_bank_question_fragment_skip_links_to_bank_endpoint(
+    client_with_question: TestClient,
+) -> None:
+    response = client_with_question.get(
+        "/ui/myctx/question/bank?focus_area=Agent+Development&session_id=sess-1"
+    )
+
+    assert "/ui/myctx/question/bank" in response.text
+
+
 def test_get_bank_question_fragment_form_posts_to_submit(
     client_with_question: TestClient,
 ) -> None:

--- a/tests/test_api_history.py
+++ b/tests/test_api_history.py
@@ -26,7 +26,7 @@ def client() -> Generator[TestClient]:
 def _attempt(
     question: str = "What is X?",
     answer: str = "It is Y.",
-    score: int = 7,
+    score: int | None = 7,
     result: dict[str, object] | None = None,
 ) -> QuestionAttempt:
     return QuestionAttempt(
@@ -150,6 +150,32 @@ def test_get_history_malformed_result_json_falls_back_to_none(client: TestClient
 
     assert response.status_code == 200
     assert "6/10" in response.text  # attempt still rendered, just no breakdown
+
+
+def test_get_history_renders_unevaluated_attempt_without_500(client: TestClient) -> None:
+    app.state.session_stores = {}
+    app.state.session_stores["my-context"] = MagicMock()
+    app.state.session_stores["my-context"].load_sessions.return_value = [
+        _session([_attempt(score=None)])
+    ]
+
+    response = client.get("/ui/my-context/history")
+
+    assert response.status_code == 200
+    assert "pending" in response.text
+
+
+def test_get_history_avg_excludes_unevaluated_attempts(client: TestClient) -> None:
+    app.state.session_stores = {}
+    app.state.session_stores["my-context"] = MagicMock()
+    app.state.session_stores["my-context"].load_sessions.return_value = [
+        _session([_attempt(score=8), _attempt(score=None)])
+    ]
+
+    response = client.get("/ui/my-context/history")
+
+    assert response.status_code == 200
+    assert "8.0/10" in response.text  # avg over scored attempts only
 
 
 def test_get_history_shows_back_link(client: TestClient) -> None:

--- a/tests/test_api_submit.py
+++ b/tests/test_api_submit.py
@@ -61,8 +61,8 @@ def test_post_submit_records_attempt_with_none_score(
     )
 
     mock_session_store.record.assert_called_once()
-    _, kwargs = mock_session_store.record.call_args
-    assert kwargs.get("score") is None or mock_session_store.record.call_args[0][3] is None
+    # record is called positionally: (session_id, question, answer, score, question_id, result_json)
+    assert mock_session_store.record.call_args[0][3] is None
 
 
 def test_post_submit_returns_next_question(

--- a/tests/test_api_submit.py
+++ b/tests/test_api_submit.py
@@ -1,0 +1,106 @@
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from core.models import BankQuestion
+
+
+def _make_client(
+    mock_bank_store: MagicMock, mock_session_store: MagicMock
+) -> Generator[tuple[TestClient, MagicMock, MagicMock]]:
+    with (
+        patch("api.main.SentenceTransformerEmbedder"),
+        patch("api.main.AsyncAnthropic"),
+        patch("api.main.genai"),
+        patch("api.main.Retriever"),
+        patch("api.main.QuestionBankStore", return_value=mock_bank_store),
+        patch("api.main.SessionStore", return_value=mock_session_store),
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        TestClient(app) as c,
+    ):
+        yield c, mock_bank_store, mock_session_store
+
+
+@pytest.fixture()
+def client_next_question() -> Generator[tuple[TestClient, MagicMock, MagicMock]]:
+    mock_bank_store = MagicMock()
+    mock_bank_store.get_random.return_value = BankQuestion.from_parts(
+        "History", "Who was Napoleon?"
+    )
+    mock_session_store = MagicMock()
+    mock_session_store.record.return_value = 42
+    yield from _make_client(mock_bank_store, mock_session_store)
+
+
+@pytest.fixture()
+def client_bank_exhausted() -> Generator[tuple[TestClient, MagicMock, MagicMock]]:
+    mock_bank_store = MagicMock()
+    mock_bank_store.get_random.return_value = None
+    mock_session_store = MagicMock()
+    mock_session_store.record.return_value = 1
+    yield from _make_client(mock_bank_store, mock_session_store)
+
+
+def test_post_submit_records_attempt_with_none_score(
+    client_next_question: tuple[TestClient, MagicMock, MagicMock],
+) -> None:
+    client, _, mock_session_store = client_next_question
+
+    client.post(
+        "/ui/myctx/submit",
+        data={
+            "question": "What is X?",
+            "answer": "It is Y.",
+            "question_id": "qid-1",
+            "query": "History",
+            "session_id": "sess-1",
+        },
+    )
+
+    mock_session_store.record.assert_called_once()
+    _, kwargs = mock_session_store.record.call_args
+    assert kwargs.get("score") is None or mock_session_store.record.call_args[0][3] is None
+
+
+def test_post_submit_returns_next_question(
+    client_next_question: tuple[TestClient, MagicMock, MagicMock],
+) -> None:
+    client, _, _ = client_next_question
+
+    response = client.post(
+        "/ui/myctx/submit",
+        data={
+            "question": "What is X?",
+            "answer": "It is Y.",
+            "question_id": "qid-1",
+            "query": "History",
+            "session_id": "sess-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Who was Napoleon?" in response.text
+
+
+def test_post_submit_returns_bank_empty_when_exhausted(
+    client_bank_exhausted: tuple[TestClient, MagicMock, MagicMock],
+) -> None:
+    client, _, _ = client_bank_exhausted
+
+    response = client.post(
+        "/ui/myctx/submit",
+        data={
+            "question": "What is X?",
+            "answer": "It is Y.",
+            "question_id": "qid-1",
+            "query": "History",
+            "session_id": "sess-1",
+        },
+    )
+
+    assert response.status_code == 200
+    assert "No questions in the bank" in response.text

--- a/tests/test_api_ui.py
+++ b/tests/test_api_ui.py
@@ -146,6 +146,18 @@ def test_get_question_fragment_contains_answer_form(
     assert "textarea" in response.text
 
 
+def test_get_question_fragment_form_posts_to_evaluate(
+    client: TestClient, mock_retriever: MagicMock
+) -> None:
+    mock_retriever.retrieve.return_value = [("chunk", 0.9)]
+    with patch(
+        "api.main.generate_question_gemini", new=AsyncMock(return_value=Question(text="What is X?"))
+    ):
+        response = client.get("/ui/my-context/question?query=topic&session_id=test-session-id")
+
+    assert "/ui/my-context/evaluate" in response.text
+
+
 def test_get_question_fragment_passes_query_to_form(
     client: TestClient, mock_retriever: MagicMock
 ) -> None:

--- a/tests/test_session_models.py
+++ b/tests/test_session_models.py
@@ -16,6 +16,17 @@ def test_question_attempt_fields() -> None:
     assert attempt.timestamp == "2026-03-21T10:00:00"
 
 
+def test_question_attempt_score_can_be_none() -> None:
+    attempt = QuestionAttempt(
+        session_id="s1",
+        question_text="What is X?",
+        answer_text="It is Y.",
+        score=None,
+        timestamp="2026-04-11T10:00:00",
+    )
+    assert attempt.score is None
+
+
 def test_session_record_fields() -> None:
     attempt = QuestionAttempt(
         session_id="s1",

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -510,6 +510,70 @@ def test_existing_db_migrates_to_add_focus_area(tmp_path: Path) -> None:
     assert "focus_area" in cols
 
 
+def test_record_round_trip_with_none_score(tmp_path: Path) -> None:
+    """Attempt recorded with score=None loads back with score=None."""
+    store = SessionStore(tmp_path, "ctx")
+    session_id = store.start_session()
+    store.record(session_id, "What is X?", "It is Y.", None)
+
+    sessions = store.load_sessions()
+
+    assert sessions[0].attempts[0].score is None
+
+
+def test_fresh_db_score_column_is_nullable(tmp_path: Path) -> None:
+    """Fresh DB created via migrations has score column as nullable on attempts table."""
+    SessionStore(tmp_path, "ctx")
+
+    db_path = tmp_path / "ctx" / "sessions.db"
+    with sqlite3.connect(db_path) as conn:
+        # PRAGMA table_info row: (cid, name, type, notnull, dflt_value, pk)
+        # notnull=0 means the column is nullable
+        cols = {row[1]: row[3] for row in conn.execute("PRAGMA table_info(attempts)").fetchall()}
+
+    assert cols["score"] == 0
+
+
+def test_existing_db_migrates_score_to_nullable(tmp_path: Path) -> None:
+    """Existing DB with score NOT NULL gets score column made nullable via migration."""
+    ctx_dir = tmp_path / "ctx"
+    ctx_dir.mkdir()
+    db_path = ctx_dir / "sessions.db"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            "CREATE TABLE sessions"
+            " (session_id TEXT PRIMARY KEY, context TEXT NOT NULL, started_at TEXT NOT NULL);"
+            "CREATE TABLE attempts"
+            " (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,"
+            " question_id TEXT, question_text TEXT NOT NULL, answer_text TEXT NOT NULL,"
+            " score INTEGER NOT NULL, result_json TEXT, timestamp TEXT NOT NULL,"
+            " focus_area TEXT);"
+            "CREATE TABLE chunks"
+            " (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " attempt_id INTEGER NOT NULL REFERENCES attempts(id),"
+            " chunk_text TEXT NOT NULL, score REAL);"
+            "CREATE TABLE annotations"
+            " (id INTEGER PRIMARY KEY AUTOINCREMENT, attempt_id INTEGER REFERENCES attempts(id),"
+            " question_id TEXT, target_type TEXT NOT NULL, sentiment TEXT NOT NULL,"
+            " comment TEXT, created_at TEXT NOT NULL, flagged_at TEXT,"
+            " UNIQUE(question_id, target_type));"
+            "CREATE TABLE alembic_version"
+            " (version_num VARCHAR(32) NOT NULL CONSTRAINT alembic_version_pkc PRIMARY KEY);"
+            "INSERT INTO alembic_version VALUES ('d9c3a7b15e62');"
+            "INSERT INTO sessions VALUES ('s1', 'ctx', '2024-01-01T00:00:00+00:00');"
+            "INSERT INTO attempts"
+            " VALUES (1, 's1', 'qid-1', 'Q?', 'A.', 5, NULL, '2024-01-01T00:00:00+00:00', NULL);"
+        )
+
+    SessionStore(tmp_path, "ctx")
+
+    with sqlite3.connect(db_path) as conn:
+        cols = {row[1]: row[3] for row in conn.execute("PRAGMA table_info(attempts)").fetchall()}
+
+    assert cols["score"] == 0  # nullable after migration
+
+
 def test_load_annotations_flagged_and_sentiment_combined(tmp_path: Path) -> None:
     store = SessionStore(tmp_path, "ctx")
     store.start_session()


### PR DESCRIPTION
Closes #243

## What broke

`question.html` posted to `/ui/{context}/evaluate`, which requires a chunk store (`chunks.json` + `embeddings.npy`). Contexts created via MCP or the import flow never run ingestion, so those files don't exist. The endpoint returned 404; HTMX silently ignores non-2xx responses, making the button appear unresponsive.

## What this does

Three atomic commits:

1. **feat(session): allow nullable score on attempts** — migration 004 makes `attempts.score` nullable (`INTEGER` instead of `INTEGER NOT NULL`); `QuestionAttempt.score` and `SessionStore.record()` updated to `int | None`.

2. **feat(ui): add POST /ui/{context_name}/submit** — records the attempt with `score=None` (no inline evaluation), concurrently fetches the next bank question, and returns the question fragment or `bank_empty.html` when exhausted.

3. **fix(ui): wire question.html form to /submit** — changes `hx-post` target from `/evaluate` to `/submit`.

The existing `/evaluate` endpoint is unchanged; it continues to work for contexts that have a chunk store.

## Test plan

- [ ] All 389 tests pass (`uv run pytest`)
- [ ] `test_api_submit.py`: attempt recorded with `score=None`, next question returned, bank-empty returned when bank exhausted
- [ ] `test_session_store.py`: nullable score round-trip, fresh DB nullable, existing DB migrated
- [ ] `test_api_bank.py`: bank question fragment form posts to `/submit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)