### PR TITLE
Add code style convention for blank line grouping

### DIFF
--- a/docs/conventions/004-code-style.md
+++ b/docs/conventions/004-code-style.md
@@ -1,0 +1,23 @@
+# Convention — Code style
+
+## Grouping in large functions
+
+When a function has multiple initialization steps or logical sections (especially 5+ lines), separate each group with a blank line to improve readability.
+
+Example:
+```python
+# storage setup
+store_dir = STORE_DIR
+embedder = SentenceTransformerEmbedder()
+store = ChunkStore(store_dir)
+
+# rag components
+app.state.retriever = Retriever(store=store, embedder=embedder)
+app.state.context_store = ContextStore(store_dir)
+
+# api clients
+app.state.anthropic = AsyncAnthropic()
+app.state.gemini = genai.Client()
+```
+
+This makes the code's structure scannable at a glance. Add a comment only if the group's purpose isn't obvious from the code.

--- a/src/learning_tool/api/main.py
+++ b/src/learning_tool/api/main.py
@@ -35,21 +35,30 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         level=LOG_LEVEL,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+
+    # storage
     store_dir = STORE_DIR
     logger.info("store dir: %s", store_dir)
     embedder = SentenceTransformerEmbedder()
     store = ChunkStore(store_dir)
+
     app.state.retriever = Retriever(store=store, embedder=embedder)
     logger.info("retriever ready")
+
+    # rag
     app.state.store_dir = store_dir
     app.state.context_store = ContextStore(store_dir)
     app.state.draft_store = DraftStore(store_dir)
+
+    # api clients
     if not os.environ.get("GEMINI_API_KEY"):
         raise ValueError("GEMINI_API_KEY is not set")
     app.state.anthropic = AsyncAnthropic()
     logger.info("anthropic client ready")
     app.state.gemini = genai.Client()
     logger.info("gemini client ready")
+
+    # caches
     app.state.session_stores = {}  # dict[str, SessionStore], keyed by context name
     app.state.bank_stores = {}  # dict[str, QuestionBankStore], keyed by context name
     yield


### PR DESCRIPTION
## Summary

Documents and applies a code style convention for organizing large functions: separate logical sections with blank lines to improve readability.

- Defines the convention in `docs/conventions/004-code-style.md`
- Applies it to the lifespan initialization in `main.py`

## Test plan

- Code passes linting, formatting, and type checks
- No functional changes—organizational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)