### PR TITLE
refactor: extract CLI command helpers to eliminate boilerplate

### DIFF
--- a/src/learning_tool/cli/main.py
+++ b/src/learning_tool/cli/main.py
@@ -10,11 +10,12 @@ from learning_tool.core.evaluation.prompt import build_evaluation_prompt
 from learning_tool.core.ingestion.context import extract_context
 from learning_tool.core.ingestion.ingest import ingest
 from learning_tool.core.ingestion.sources import walk_source_dir
-from learning_tool.core.models import UserProfile
+from learning_tool.core.models import ContextMetadata, EvaluationResult, UserProfile
 from learning_tool.core.question.generate import generate_question
 from learning_tool.core.question.loader import load_questions
 from learning_tool.core.question.prompt import build_question_prompt
 from learning_tool.core.question.store import QuestionBankStore
+from learning_tool.core.rag.retriever import Retriever
 from learning_tool.core.session.store import SessionStore
 from learning_tool.core.settings import LOG_LEVEL
 from learning_tool.core.settings import STORE_DIR as DEFAULT_STORE
@@ -132,21 +133,43 @@ def load_questions_cmd(
     typer.echo(f"Loaded {added} new question(s) into '{context}' ({len(questions)} in file).")
 
 
-def _build_prompt(
-    stores: Stores,
+def setup_context_resources(
     context: str,
     query: str,
     experience_level: str,
     k: int,
-) -> str:
+    stores: Stores,
+) -> tuple[Retriever, UserProfile, ContextMetadata | None, list[str]]:
+    """Validate context, load profile/metadata, and retrieve chunks."""
     ctx_dir = stores.store_dir / context
     if not ctx_dir.exists():
         typer.echo(f"Error: context '{context}' not found. Run 'make ingest' first.", err=True)
         raise typer.Exit(code=1)
+
     metadata = stores.context_store.load_context(context)
     profile = UserProfile(experience_level=experience_level)
     chunks = [chunk for chunk, _ in stores.retriever.retrieve(context, query, k)]
-    return build_question_prompt(chunks, profile, metadata)
+    return stores.retriever, profile, metadata, chunks
+
+
+def print_evaluation_results(evaluation: EvaluationResult) -> str:
+    """Format evaluation results into a printable string."""
+    parts = [f"Score: {evaluation.score}/10"]
+    if evaluation.strengths:
+        parts.append("\nStrengths:")
+        for s in evaluation.strengths:
+            parts.append(f"  - {s}")
+    if evaluation.gaps:
+        parts.append("\nGaps:")
+        for g in evaluation.gaps:
+            parts.append(f"  - {g}")
+    if evaluation.missing_points:
+        parts.append("\nMissing points:")
+        for m in evaluation.missing_points:
+            parts.append(f"  - {m}")
+    if evaluation.suggested_addition:
+        parts.append(f"\nSuggested addition: {evaluation.suggested_addition}")
+    return "\n".join(parts)
 
 
 @app.command()
@@ -159,7 +182,10 @@ def question_prompt(
 ) -> None:
     """Print the question prompt that would be sent to Claude."""
     stores: Stores = ctx.obj
-    print(_build_prompt(stores, context, query, experience_level, k))
+    _, profile, metadata, chunks = setup_context_resources(
+        context, query, experience_level, k, stores
+    )
+    print(build_question_prompt(chunks, profile, metadata))
 
 
 @app.command()
@@ -172,7 +198,10 @@ def question(
 ) -> None:
     """Generate a practice question from retrieved chunks using Claude."""
     stores: Stores = ctx.obj
-    prompt = _build_prompt(stores, context, query, experience_level, k)
+    _, profile, metadata, chunks = setup_context_resources(
+        context, query, experience_level, k, stores
+    )
+    prompt = build_question_prompt(chunks, profile, metadata)
     result = asyncio.run(generate_question(prompt, AsyncAnthropic()))
     print(result.text)
 
@@ -189,32 +218,18 @@ def evaluate(
 ) -> None:
     """Evaluate a learner's answer to a question using Claude."""
     stores: Stores = ctx.obj
-    metadata = stores.context_store.load_context(context)
-    profile = UserProfile(experience_level=experience_level)
-    chunks = [chunk for chunk, _ in stores.retriever.retrieve(context, query, k)]
-    prompt = build_evaluation_prompt(
+    _, profile, metadata, chunks = setup_context_resources(
+        context, query, experience_level, k, stores
+    )
+    eval_prompt = build_evaluation_prompt(
         question=question_text,
         answer=answer_text,
         chunks=chunks,
         profile=profile,
         metadata=metadata,
     )
-    result = asyncio.run(evaluate_answer(prompt, AsyncAnthropic()))
-    print(f"Score: {result.score}/10")
-    if result.strengths:
-        print("\nStrengths:")
-        for s in result.strengths:
-            print(f"  - {s}")
-    if result.gaps:
-        print("\nGaps:")
-        for g in result.gaps:
-            print(f"  - {g}")
-    if result.missing_points:
-        print("\nMissing points:")
-        for m in result.missing_points:
-            print(f"  - {m}")
-    if result.suggested_addition:
-        print(f"\nSuggested addition: {result.suggested_addition}")
+    result = asyncio.run(evaluate_answer(eval_prompt, AsyncAnthropic()))
+    print(print_evaluation_results(result))
     if result.follow_up_question:
         print(f"\nFollow-up question: {result.follow_up_question}")
 
@@ -229,18 +244,12 @@ def practice(
 ) -> None:
     """Interactive practice loop — question, answer, evaluate, repeat."""
     stores: Stores = ctx.obj
-    ctx_dir = stores.store_dir / context
-    if not ctx_dir.exists():
-        typer.echo(f"Error: context '{context}' not found. Run 'make ingest' first.", err=True)
-        raise typer.Exit(code=1)
 
     async def loop() -> None:
         client = AsyncAnthropic()
-        profile = UserProfile(experience_level=experience_level)
-        metadata = stores.context_store.load_context(context)
-        # Chunks are retrieved once per topic query and reused across follow-ups,
-        # since follow-up questions target gaps within the same retrieved context.
-        chunks = [chunk for chunk, _ in stores.retriever.retrieve(context, query, k)]
+        _, profile, metadata, chunks = setup_context_resources(
+            context, query, experience_level, k, stores
+        )
 
         # Context-scoped stores are created on demand using the shared store_dir
         session_store = SessionStore(stores.store_dir, context)
@@ -266,21 +275,7 @@ def practice(
 
             session_store.record(session_id, next_question, answer, evaluation.score)
 
-            print(f"\nScore: {evaluation.score}/10")
-            if evaluation.strengths:
-                print("\nStrengths:")
-                for s in evaluation.strengths:
-                    print(f"  - {s}")
-            if evaluation.gaps:
-                print("\nGaps:")
-                for g in evaluation.gaps:
-                    print(f"  - {g}")
-            if evaluation.missing_points:
-                print("\nMissing points:")
-                for m in evaluation.missing_points:
-                    print(f"  - {m}")
-            if evaluation.suggested_addition:
-                print(f"\nSuggested addition: {evaluation.suggested_addition}")
+            print(f"\n{print_evaluation_results(evaluation)}")
 
             if evaluation.follow_up_question:
                 next_question = evaluation.follow_up_question

--- a/tests/cli/test_cli_helpers.py
+++ b/tests/cli/test_cli_helpers.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from learning_tool.cli.main import print_evaluation_results, setup_context_resources
+from learning_tool.core.models import ContextMetadata, EvaluationResult, UserProfile
+from learning_tool.core.stores import Stores
+
+
+def test_print_evaluation_results_all_fields() -> None:
+    evaluation = EvaluationResult(
+        score=8,
+        strengths=["Strong grasp of the basics", "Good examples"],
+        gaps=["Could explain the 'why' more"],
+        missing_points=["Missing the final step"],
+        suggested_addition="Add a summary of the benefits.",
+        follow_up_question="How would you handle the edge case?",
+    )
+    output = print_evaluation_results(evaluation)
+
+    assert "Score: 8/10" in output
+    assert "Strengths:" in output
+    assert "- Strong grasp of the basics" in output
+    assert "- Good examples" in output
+    assert "Gaps:" in output
+    assert "- Could explain the 'why' more" in output
+    assert "Missing points:" in output
+    assert "- Missing the final step" in output
+    assert "Suggested addition: Add a summary of the benefits." in output
+
+
+def test_print_evaluation_results_minimal() -> None:
+    evaluation = EvaluationResult(
+        score=10,
+        strengths=[],
+        gaps=[],
+        missing_points=[],
+        suggested_addition=None,
+        follow_up_question="Great job!",
+    )
+    output = print_evaluation_results(evaluation)
+
+    assert output == "Score: 10/10"
+
+
+def test_setup_context_resources_success(tmp_path: Path) -> None:
+    context = "test-context"
+    (tmp_path / context).mkdir()
+
+    mock_stores = MagicMock(spec=Stores)
+    mock_stores.store_dir = tmp_path
+    mock_stores.context_store.load_context.return_value = ContextMetadata(
+        goal="Test goal", focus_areas=["area1"]
+    )
+    mock_stores.retriever.retrieve.return_value = [("chunk1", 0.9), ("chunk2", 0.8)]
+
+    retriever, profile, metadata, chunks = setup_context_resources(
+        context=context,
+        query="test query",
+        experience_level="expert",
+        k=2,
+        stores=mock_stores,
+    )
+
+    assert retriever == mock_stores.retriever
+    assert isinstance(profile, UserProfile)
+    assert profile.experience_level == "expert"
+    assert metadata is not None
+    assert metadata.goal == "Test goal"
+    assert chunks == ["chunk1", "chunk2"]
+    mock_stores.retriever.retrieve.assert_called_once_with(context, "test query", 2)
+
+
+def test_setup_context_resources_missing_context(tmp_path: Path) -> None:
+    mock_stores = MagicMock(spec=Stores)
+    mock_stores.store_dir = tmp_path
+
+    with pytest.raises(typer.Exit) as exc:
+        setup_context_resources(
+            context="missing-context",
+            query="test",
+            experience_level="beginner",
+            k=5,
+            stores=mock_stores,
+        )
+
+    assert exc.value.exit_code == 1


### PR DESCRIPTION
This PR extracts reusable helpers in the CLI to eliminate repetitive setup patterns:

1. setup_context_resources(): Validates context, initializes stores, and retrieves chunks/metadata.
2. print_evaluation_results(): Standardizes the formatting of evaluation results.

These changes shrink the size of core CLI commands and improve maintainability.

Co-Authored-By: Gemini 2.0 Flash <noreply@google.com>